### PR TITLE
Use local IDs for hashes in the clients

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(PMP_CLIENT_SOURCES
     client/dynamicmodecontrollerimpl.cpp
     client/generalcontrollerimpl.cpp
     client/historycontrollerimpl.cpp
+    client/localhashidrepository.cpp
     client/playercontrollerimpl.cpp
     client/queuecontrollerimpl.cpp
     client/queueentryinfofetcher.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PMP_COMMON_HEADERS
 
 set(PMP_CLIENT_SOURCES
     client/authenticationcontrollerimpl.cpp
+    client/clientmetatypes.cpp
     client/collectionwatcherimpl.cpp
     client/currenttrackmonitorimpl.cpp
     client/dynamicmodecontrollerimpl.cpp

--- a/src/client/clientmetatypes.cpp
+++ b/src/client/clientmetatypes.cpp
@@ -1,0 +1,39 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "localhashid.h"
+
+namespace PMP::Client
+{
+    /** Utility object to automatically do the qRegisterMetaType calls at program
+     *  startup */
+    class ClientMetatypesInit
+    {
+    protected:
+        ClientMetatypesInit()
+        {
+            qRegisterMetaType<PMP::Client::LocalHashId>();
+        }
+
+    private:
+        static ClientMetatypesInit GlobalVariable;
+    };
+
+    ClientMetatypesInit ClientMetatypesInit::GlobalVariable;
+}

--- a/src/client/clientmetatypes.cpp
+++ b/src/client/clientmetatypes.cpp
@@ -17,6 +17,7 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "collectiontrackinfo.h"
 #include "localhashid.h"
 
 namespace PMP::Client
@@ -28,6 +29,7 @@ namespace PMP::Client
     protected:
         ClientMetatypesInit()
         {
+            qRegisterMetaType<PMP::Client::CollectionTrackInfo>();
             qRegisterMetaType<PMP::Client::LocalHashId>();
         }
 

--- a/src/client/collectionfetcher.h
+++ b/src/client/collectionfetcher.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,10 +17,10 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_COLLECTIONFETCHER_H
-#define PMP_COLLECTIONFETCHER_H
+#ifndef PMP_CLIENT_COLLECTIONFETCHER_H
+#define PMP_CLIENT_COLLECTIONFETCHER_H
 
-#include "common/collectiontrackinfo.h"
+#include "collectiontrackinfo.h"
 
 #include <QObject>
 #include <QVector>

--- a/src/client/collectiontrackinfo.h
+++ b/src/client/collectiontrackinfo.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,15 +17,15 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_COLLECTIONTRACKINFO_H
-#define PMP_COLLECTIONTRACKINFO_H
+#ifndef PMP_CLIENT_COLLECTIONTRACKINFO_H
+#define PMP_CLIENT_COLLECTIONTRACKINFO_H
 
-#include "filehash.h"
+#include "localhashid.h"
 
 #include <QMetaType>
 #include <QString>
 
-namespace PMP
+namespace PMP::Client
 {
     class CollectionTrackInfo
     {
@@ -36,22 +36,22 @@ namespace PMP
             //
         }
 
-        CollectionTrackInfo(FileHash const& hash, bool isAvailable)
-         : _hash(hash), _isAvailable(isAvailable), _lengthInMs(-1)
+        CollectionTrackInfo(LocalHashId hashId, bool isAvailable)
+         : _hashId(hashId), _isAvailable(isAvailable), _lengthInMs(-1)
         {
             //
         }
 
-        CollectionTrackInfo(FileHash const& hash, bool isAvailable,
+        CollectionTrackInfo(LocalHashId hashId, bool isAvailable,
                             QString const& title, QString const& artist,
                             QString const& album, qint32 lengthInMilliseconds)
-         : _hash(hash), _isAvailable(isAvailable), _lengthInMs(lengthInMilliseconds),
+         : _hashId(hashId), _isAvailable(isAvailable), _lengthInMs(lengthInMilliseconds),
            _title(title), _artist(artist), _album(album)
         {
             //
         }
 
-        const FileHash& hash() const { return _hash; }
+        constexpr LocalHashId hashId() const { return _hashId; }
 
         void setAvailable(bool available) { _isAvailable = available; }
         bool isAvailable() const { return _isAvailable; }
@@ -73,7 +73,7 @@ namespace PMP
         }
 
     private:
-        FileHash _hash;
+        LocalHashId _hashId;
         bool _isAvailable;
         qint32 _lengthInMs;
         QString _title, _artist, _album;
@@ -82,7 +82,7 @@ namespace PMP
     inline bool operator==(const CollectionTrackInfo& me,
                            const CollectionTrackInfo& other)
     {
-        return me.hash() == other.hash()
+        return me.hashId() == other.hashId()
             && me.isAvailable() == other.isAvailable()
             && me.lengthInMilliseconds() == other.lengthInMilliseconds()
             && me.title() == other.title()
@@ -97,6 +97,6 @@ namespace PMP
     }
 }
 
-Q_DECLARE_METATYPE(PMP::CollectionTrackInfo)
+Q_DECLARE_METATYPE(PMP::Client::CollectionTrackInfo)
 
 #endif

--- a/src/client/collectionwatcher.h
+++ b/src/client/collectionwatcher.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,10 +17,10 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_COLLECTIONWATCHER_H
-#define PMP_COLLECTIONWATCHER_H
+#ifndef PMP_CLIENT_COLLECTIONWATCHER_H
+#define PMP_CLIENT_COLLECTIONWATCHER_H
 
-#include "common/collectiontrackinfo.h"
+#include "collectiontrackinfo.h"
 
 #include <QHash>
 #include <QObject>
@@ -36,13 +36,13 @@ namespace PMP::Client
         virtual void enableCollectionDownloading() = 0;
         virtual bool downloadingInProgress() const = 0;
 
-        virtual QHash<FileHash, CollectionTrackInfo> getCollection() = 0;
-        virtual CollectionTrackInfo getTrack(FileHash const& hash) = 0;
+        virtual QHash<LocalHashId, CollectionTrackInfo> getCollection() = 0;
+        virtual CollectionTrackInfo getTrack(LocalHashId hashId) = 0;
 
     Q_SIGNALS:
         void downloadingInProgressChanged();
         void newTrackReceived(CollectionTrackInfo track);
-        void trackAvailabilityChanged(FileHash hash, bool isAvailable);
+        void trackAvailabilityChanged(LocalHashId hashId, bool isAvailable);
         void trackDataChanged(CollectionTrackInfo track);
 
     protected:

--- a/src/client/collectionwatcherimpl.cpp
+++ b/src/client/collectionwatcherimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -61,14 +61,14 @@ namespace PMP::Client
         return _downloading;
     }
 
-    QHash<FileHash, CollectionTrackInfo> CollectionWatcherImpl::getCollection()
+    QHash<LocalHashId, CollectionTrackInfo> CollectionWatcherImpl::getCollection()
     {
         return _collectionHash;
     }
 
-    CollectionTrackInfo CollectionWatcherImpl::getTrack(const FileHash& hash)
+    CollectionTrackInfo CollectionWatcherImpl::getTrack(LocalHashId hashId)
     {
-        auto it = _collectionHash.find(hash);
+        auto it = _collectionHash.find(hashId);
 
         if (it == _collectionHash.end())
             return CollectionTrackInfo();
@@ -89,10 +89,10 @@ namespace PMP::Client
 
         for (auto const& track : tracks)
         {
-            if (_collectionHash.contains(track.hash()))
+            if (_collectionHash.contains(track.hashId()))
                 continue; /* don't update */
 
-            _collectionHash.insert(track.hash(), track);
+            _collectionHash.insert(track.hashId(), track);
             Q_EMIT newTrackReceived(track);
         }
     }
@@ -112,8 +112,8 @@ namespace PMP::Client
     }
 
     void CollectionWatcherImpl::onCollectionTracksAvailabilityChanged(
-                                                            QVector<FileHash> available,
-                                                            QVector<FileHash> unavailable)
+                                                         QVector<LocalHashId> available,
+                                                         QVector<LocalHashId> unavailable)
     {
         updateTrackAvailability(available, true);
         updateTrackAvailability(unavailable, false);
@@ -154,7 +154,7 @@ namespace PMP::Client
         Q_EMIT downloadingInProgressChanged();
     }
 
-    void CollectionWatcherImpl::updateTrackAvailability(QVector<FileHash> hashes,
+    void CollectionWatcherImpl::updateTrackAvailability(QVector<LocalHashId> hashes,
                                                         bool available)
     {
         for (auto const& hash : hashes)
@@ -190,11 +190,11 @@ namespace PMP::Client
 
     void CollectionWatcherImpl::updateTrackData(const CollectionTrackInfo& track)
     {
-        auto it = _collectionHash.find(track.hash());
+        auto it = _collectionHash.find(track.hashId());
 
         if (it == _collectionHash.end()) /* the track is unknown to us */
         {
-            _collectionHash.insert(track.hash(), track);
+            _collectionHash.insert(track.hashId(), track);
             Q_EMIT newTrackReceived(track);
             return;
         }

--- a/src/client/collectionwatcherimpl.h
+++ b/src/client/collectionwatcherimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,8 +17,8 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_COLLECTIONWATCHERIMPL_H
-#define PMP_COLLECTIONWATCHERIMPL_H
+#ifndef PMP_CLIENT_COLLECTIONWATCHERIMPL_H
+#define PMP_CLIENT_COLLECTIONWATCHERIMPL_H
 
 #include "collectionwatcher.h"
 
@@ -38,25 +38,26 @@ namespace PMP::Client
         void enableCollectionDownloading() override;
         bool downloadingInProgress() const override;
 
-        QHash<FileHash, CollectionTrackInfo> getCollection() override;
-        CollectionTrackInfo getTrack(FileHash const& hash) override;
+        QHash<LocalHashId, CollectionTrackInfo> getCollection() override;
+        CollectionTrackInfo getTrack(LocalHashId hashId) override;
 
     private Q_SLOTS:
         void onConnected();
         void onCollectionPartReceived(QVector<CollectionTrackInfo> tracks);
         void onCollectionDownloadCompleted();
         void onCollectionDownloadError();
-        void onCollectionTracksAvailabilityChanged(QVector<PMP::FileHash> available,
-                                                   QVector<PMP::FileHash> unavailable);
-        void onCollectionTracksChanged(QVector<PMP::CollectionTrackInfo> changes);
+        void onCollectionTracksAvailabilityChanged(
+                                           QVector<PMP::Client::LocalHashId> available,
+                                           QVector<PMP::Client::LocalHashId> unavailable);
+        void onCollectionTracksChanged(QVector<PMP::Client::CollectionTrackInfo> changes);
 
     private:
         void startDownload();
-        void updateTrackAvailability(QVector<FileHash> hashes, bool available);
+        void updateTrackAvailability(QVector<LocalHashId> hashes, bool available);
         void updateTrackData(CollectionTrackInfo const& track);
 
         ServerConnection* _connection;
-        QHash<FileHash, CollectionTrackInfo> _collectionHash;
+        QHash<LocalHashId, CollectionTrackInfo> _collectionHash;
         bool _autoDownload;
         bool _downloading;
     };

--- a/src/client/currenttrackmonitor.h
+++ b/src/client/currenttrackmonitor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,12 +17,13 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_CURRENTTRACKMONITOR_H
-#define PMP_CURRENTTRACKMONITOR_H
+#ifndef PMP_CLIENT_CURRENTTRACKMONITOR_H
+#define PMP_CLIENT_CURRENTTRACKMONITOR_H
 
-#include "common/filehash.h"
 #include "common/tribool.h"
 #include "common/playerstate.h"
+
+#include "localhashid.h"
 
 #include <QObject>
 
@@ -40,7 +41,7 @@ namespace PMP::Client
         virtual quint32 currentQueueId() const = 0;
         virtual qint64 currentTrackProgressMilliseconds() const = 0;
 
-        virtual FileHash currentTrackHash() const = 0;
+        virtual LocalHashId currentTrackHash() const = 0;
 
         virtual QString currentTrackTitle() const = 0;
         virtual QString currentTrackArtist() const = 0;

--- a/src/client/currenttrackmonitorimpl.cpp
+++ b/src/client/currenttrackmonitorimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -35,7 +35,7 @@ namespace PMP::Client
        _playerState(PlayerState::Unknown),
        _currentQueueId(0),
        _progressAtTimerStart(0),
-       _currentHash(),
+       _currentHashId{},
        _haveReceivedCurrentTrack(false),
        _currentTrackLengthMilliseconds(-1)
     {
@@ -88,9 +88,9 @@ namespace PMP::Client
         return progress;
     }
 
-    FileHash CurrentTrackMonitorImpl::currentTrackHash() const
+    LocalHashId CurrentTrackMonitorImpl::currentTrackHash() const
     {
-        return _currentHash;
+        return _currentHashId;
     }
 
     QString CurrentTrackMonitorImpl::currentTrackTitle() const
@@ -175,7 +175,7 @@ namespace PMP::Client
 
     void CurrentTrackMonitorImpl::updateTrackFields(bool isNewTrack)
     {
-        FileHash hash;
+        LocalHashId hashId;
         QString title;
         QString artist;
         QString possibleFilename;
@@ -184,7 +184,7 @@ namespace PMP::Client
         auto* entry = _queueEntryInfoStorage->entryInfoByQueueId(_currentQueueId);
         if (entry)
         {
-            hash = entry->hash();
+            hashId = entry->hashId();
             title = entry->title();
             artist = entry->artist();
             possibleFilename = entry->informativeFilename();
@@ -193,13 +193,13 @@ namespace PMP::Client
 
         bool lengthChanged = lengthMilliseconds != _currentTrackLengthMilliseconds;
         bool fieldsChanged =
-                hash != _currentHash
+                hashId != _currentHashId
                 || title != _currentTrackTitle
                 || artist != _currentTrackArtist
                 || possibleFilename != _currentTrackPossibleFilename
                 || lengthChanged;
 
-        _currentHash = hash;
+        _currentHashId = hashId;
         _currentTrackTitle = title;
         _currentTrackArtist = artist;
         _currentTrackPossibleFilename = possibleFilename;
@@ -246,7 +246,7 @@ namespace PMP::Client
 
     void CurrentTrackMonitorImpl::clearTrackInfo()
     {
-        _currentHash = FileHash();
+        _currentHashId = {};
         _currentTrackTitle.clear();
         _currentTrackArtist.clear();
         _currentTrackPossibleFilename.clear();

--- a/src/client/currenttrackmonitorimpl.h
+++ b/src/client/currenttrackmonitorimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -42,7 +42,7 @@ namespace PMP::Client
         quint32 currentQueueId() const override;
         qint64 currentTrackProgressMilliseconds() const override;
 
-        FileHash currentTrackHash() const override;
+        LocalHashId currentTrackHash() const override;
 
         QString currentTrackTitle() const override;
         QString currentTrackArtist() const override;
@@ -72,7 +72,7 @@ namespace PMP::Client
         quint32 _currentQueueId;
         QElapsedTimer _progressTimer;
         qint64 _progressAtTimerStart;
-        FileHash _currentHash;
+        LocalHashId _currentHashId;
         bool _haveReceivedCurrentTrack;
         QString _currentTrackTitle;
         QString _currentTrackArtist;

--- a/src/client/localhashid.h
+++ b/src/client/localhashid.h
@@ -36,12 +36,12 @@ namespace PMP::Client
 
         LocalHashId& operator=(LocalHashId const&) = default;
 
-        constexpr bool operator==(LocalHashId const& other)
+        constexpr bool operator==(LocalHashId const& other) const
         {
             return _id == other._id;
         }
 
-        constexpr bool operator!=(LocalHashId const& other)
+        constexpr bool operator!=(LocalHashId const& other) const
         {
             return !(*this == other);
         }
@@ -50,13 +50,18 @@ namespace PMP::Client
         unsigned int _id;
     };
 
+    inline constexpr bool operator<(LocalHashId hashId1, LocalHashId hashId2)
+    {
+        return hashId1.value() < hashId2.value();
+    }
+
     inline QDebug operator<<(QDebug debug, const PMP::Client::LocalHashId id)
     {
         debug << id.value();
         return debug;
     }
 
-    constexpr inline size_t qHash(LocalHashId id, size_t seed)
+    constexpr inline uint qHash(LocalHashId const& id)
     {
         return id.value();
     }

--- a/src/client/localhashid.h
+++ b/src/client/localhashid.h
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_CLIENT_LOCALHASHID_H
+#define PMP_CLIENT_LOCALHASHID_H
+
+#include <QDebug>
+#include <QMetaType>
+
+namespace PMP::Client
+{
+    class LocalHashId
+    {
+    public:
+        constexpr LocalHashId() : _id(0) {}
+        constexpr explicit LocalHashId(unsigned int id) : _id(id) {}
+
+        constexpr unsigned int value() const { return _id; }
+        constexpr bool isZero() const { return _id == 0; }
+
+        LocalHashId& operator=(LocalHashId const&) = default;
+
+        constexpr bool operator==(LocalHashId const& other)
+        {
+            return _id == other._id;
+        }
+
+        constexpr bool operator!=(LocalHashId const& other)
+        {
+            return !(*this == other);
+        }
+
+    private:
+        unsigned int _id;
+    };
+
+    inline QDebug operator<<(QDebug debug, const PMP::Client::LocalHashId id)
+    {
+        debug << id.value();
+        return debug;
+    }
+
+    constexpr inline size_t qHash(LocalHashId id, size_t seed)
+    {
+        return id.value();
+    }
+}
+
+Q_DECLARE_METATYPE(PMP::Client::LocalHashId)
+
+#endif

--- a/src/client/localhashidrepository.cpp
+++ b/src/client/localhashidrepository.cpp
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "localhashidrepository.h"
+
+#include "common/filehash.h"
+
+#include <QMutexLocker>
+
+namespace PMP::Client
+{
+    LocalHashId LocalHashIdRepository::getOrRegisterId(const FileHash& hash)
+    {
+        Q_ASSERT_X(hash.isNull() == false,
+                   "LocalHashIdRepository::getOrRegisterId",
+                   "hash is null");
+
+        QMutexLocker lock(&_mutex);
+
+        auto it = _hashToId.constFind(hash);
+        if (it != _hashToId.constEnd())
+            return LocalHashId(it.value());
+
+        _lastId++;
+        LocalHashId id(_lastId);
+
+        _hashToId.insert(hash, id.value());
+        _idToHash.insert(id.value(), hash);
+        return id;
+    }
+
+    LocalHashId LocalHashIdRepository::getId(const FileHash& hash) const
+    {
+        if (hash.isNull())
+            return {}; // return zero ID
+
+        QMutexLocker lock(&_mutex);
+
+        return LocalHashId(_hashToId.value(hash, 0));
+    }
+
+    FileHash LocalHashIdRepository::getHash(LocalHashId id) const
+    {
+        if (id.isZero())
+            return {}; // return null hash
+
+        QMutexLocker lock(&_mutex);
+
+        auto it = _idToHash.constFind(id.value());
+
+        Q_ASSERT_X(it != _idToHash.constEnd(),
+                   "LocalHashIdRepository::getHash",
+                   "non-zero ID is not found");
+
+        return it.value();
+    }
+}

--- a/src/client/localhashidrepository.cpp
+++ b/src/client/localhashidrepository.cpp
@@ -22,6 +22,7 @@
 #include "common/filehash.h"
 
 #include <QMutexLocker>
+#include <QtDebug>
 
 namespace PMP::Client
 {
@@ -42,6 +43,12 @@ namespace PMP::Client
 
         _hashToId.insert(hash, id.value());
         _idToHash.insert(id.value(), hash);
+
+        if (_lastId % 500 == 0)
+        {
+            qDebug() << "registered local hash ID" << _lastId;
+        }
+
         return id;
     }
 

--- a/src/client/localhashidrepository.h
+++ b/src/client/localhashidrepository.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_CLIENT_LOCALHASHIDREPOSITORY_H
+#define PMP_CLIENT_LOCALHASHIDREPOSITORY_H
+
+#include "common/filehash.h"
+
+#include "localhashid.h"
+
+#include <QHash>
+#include <QMutex>
+
+namespace PMP::Client
+{
+    class LocalHashIdRepository
+    {
+    public:
+        LocalHashId getOrRegisterId(FileHash const& hash);
+        LocalHashId getId(FileHash const& hash) const;
+
+        FileHash getHash(LocalHashId id) const;
+
+    private:
+        mutable QMutex _mutex;
+        uint _lastId {0};
+        QHash<FileHash, uint> _hashToId;
+        QHash<uint, FileHash> _idToHash;
+    };
+}
+#endif

--- a/src/client/queuecontroller.h
+++ b/src/client/queuecontroller.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,14 +17,15 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_QUEUECONTROLLER_H
-#define PMP_QUEUECONTROLLER_H
+#ifndef PMP_CLIENT_QUEUECONTROLLER_H
+#define PMP_CLIENT_QUEUECONTROLLER_H
 
-#include "common/filehash.h"
 #include "common/queueindextype.h"
 #include "common/requestid.h"
 #include "common/resultmessageerrorcode.h"
 #include "common/specialqueueitemtype.h"
+
+#include "client/localhashid.h"
 
 #include <QObject>
 
@@ -42,9 +43,9 @@ namespace PMP::Client
 
     public Q_SLOTS:
         virtual void insertBreakAtFrontIfNotExists() = 0;
-        virtual void insertQueueEntryAtFront(FileHash hash) = 0;
-        virtual void insertQueueEntryAtEnd(FileHash hash) = 0;
-        virtual RequestID insertQueueEntryAtIndex(FileHash hash, quint32 index) = 0;
+        virtual void insertQueueEntryAtFront(LocalHashId hashId) = 0;
+        virtual void insertQueueEntryAtEnd(LocalHashId hashId) = 0;
+        virtual RequestID insertQueueEntryAtIndex(LocalHashId hashId, quint32 index) = 0;
         virtual RequestID insertSpecialItemAtIndex(SpecialQueueItemType itemType,
                                                    int index,
                                    QueueIndexType indexType = QueueIndexType::Normal) = 0;

--- a/src/client/queuecontrollerimpl.cpp
+++ b/src/client/queuecontrollerimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -79,19 +79,20 @@ namespace PMP::Client
         _connection->insertBreakAtFrontIfNotExists();
     }
 
-    void QueueControllerImpl::insertQueueEntryAtFront(FileHash hash)
+    void QueueControllerImpl::insertQueueEntryAtFront(LocalHashId hashId)
     {
-        _connection->insertQueueEntryAtFront(hash);
+        _connection->insertQueueEntryAtFront(hashId);
     }
 
-    void QueueControllerImpl::insertQueueEntryAtEnd(FileHash hash)
+    void QueueControllerImpl::insertQueueEntryAtEnd(LocalHashId hashId)
     {
-        _connection->insertQueueEntryAtEnd(hash);
+        _connection->insertQueueEntryAtEnd(hashId);
     }
 
-    RequestID QueueControllerImpl::insertQueueEntryAtIndex(FileHash hash, quint32 index)
+    RequestID QueueControllerImpl::insertQueueEntryAtIndex(LocalHashId hashId,
+                                                           quint32 index)
     {
-        return _connection->insertQueueEntryAtIndex(hash, index);
+        return _connection->insertQueueEntryAtIndex(hashId, index);
     }
 
     RequestID QueueControllerImpl::insertSpecialItemAtIndex(SpecialQueueItemType itemType,

--- a/src/client/queuecontrollerimpl.h
+++ b/src/client/queuecontrollerimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,8 +17,8 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_QUEUECONTROLLERIMPL_H
-#define PMP_QUEUECONTROLLERIMPL_H
+#ifndef PMP_CLIENT_QUEUECONTROLLERIMPL_H
+#define PMP_CLIENT_QUEUECONTROLLERIMPL_H
 
 #include "queuecontroller.h"
 
@@ -38,9 +38,9 @@ namespace PMP::Client
 
     public Q_SLOTS:
         void insertBreakAtFrontIfNotExists() override;
-        void insertQueueEntryAtFront(FileHash hash) override;
-        void insertQueueEntryAtEnd(FileHash hash) override;
-        RequestID insertQueueEntryAtIndex(FileHash hash, quint32 index) override;
+        void insertQueueEntryAtFront(LocalHashId hashId) override;
+        void insertQueueEntryAtEnd(LocalHashId hashId) override;
+        RequestID insertQueueEntryAtIndex(LocalHashId hashId, quint32 index) override;
         RequestID insertSpecialItemAtIndex(SpecialQueueItemType itemType, int index,
                                            QueueIndexType indexType) override;
         void deleteQueueEntry(uint queueId) override;

--- a/src/client/queueentryinfostorage.cpp
+++ b/src/client/queueentryinfostorage.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,8 +21,8 @@
 
 namespace PMP::Client
 {
-    QueueEntryInfo::QueueEntryInfo(quint32 queueID)
-     : _queueID(queueID), _type(QueueEntryType::Unknown), _lengthMilliseconds(-1)
+    QueueEntryInfo::QueueEntryInfo(quint32 queueId)
+     : _queueId(queueId), _type(QueueEntryType::Unknown), _lengthMilliseconds(-1)
     {
         //
     }
@@ -35,10 +35,10 @@ namespace PMP::Client
         return title().trimmed().isEmpty() || artist().trimmed().isEmpty();
     }
 
-    void QueueEntryInfo::setHash(QueueEntryType type, const FileHash& hash)
+    void QueueEntryInfo::setHash(QueueEntryType type, LocalHashId hashId)
     {
         _type = type;
-        _hash = hash;
+        _hashId = hashId;
     }
 
     void QueueEntryInfo::setInfo(QueueEntryType type, qint64 lengthInMilliseconds,

--- a/src/client/queueentryinfostorage.h
+++ b/src/client/queueentryinfostorage.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,12 +17,13 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_QUEUEENTRYINFOSTORAGE_H
-#define PMP_QUEUEENTRYINFOSTORAGE_H
+#ifndef PMP_CLIENT_QUEUEENTRYINFOSTORAGE_H
+#define PMP_CLIENT_QUEUEENTRYINFOSTORAGE_H
 
-#include "common/filehash.h"
 #include "common/queueentrytype.h"
 #include "common/tribool.h"
+
+#include "localhashid.h"
 
 #include <QObject>
 
@@ -32,9 +33,9 @@ namespace PMP::Client
     {
         Q_OBJECT
     public:
-        QueueEntryInfo(quint32 queueID);
+        QueueEntryInfo(quint32 queueId);
 
-        quint32 queueID() const { return _queueID; }
+        quint32 queueId() const { return _queueId; }
 
         TriBool isTrack() const
         {
@@ -48,7 +49,7 @@ namespace PMP::Client
         }
 
         QueueEntryType type() const { return _type; }
-        const FileHash& hash() const { return _hash; }
+        LocalHashId hashId() const { return _hashId; }
         int lengthInMilliseconds() const { return _lengthMilliseconds; }
         QString artist() const { return _artist; }
         QString title() const { return _title; }
@@ -56,15 +57,15 @@ namespace PMP::Client
         bool needFilename() const;
         QString informativeFilename() const { return _informativeFilename; }
 
-        void setHash(QueueEntryType type, const FileHash& hash);
+        void setHash(QueueEntryType type, LocalHashId hashId);
         void setInfo(QueueEntryType type, qint64 lengthInMilliseconds,
                      QString const& title, QString const& artist);
         bool setPossibleFilenames(QList<QString> const& names);
 
     private:
-        quint32 _queueID;
+        quint32 _queueId;
         QueueEntryType _type;
-        FileHash _hash;
+        LocalHashId _hashId;
         qint64 _lengthMilliseconds;
         QString _title;
         QString _artist;

--- a/src/client/queueentryinfostorageimpl.cpp
+++ b/src/client/queueentryinfostorageimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -74,7 +74,7 @@ namespace PMP::Client
                      << queueId;
             sendInfoRequest(queueId);
         }
-        else if (info->hash().isNull()
+        else if (info->hashId().isZero()
                  && !info->isTrack().isFalse()
                  && !_hashRequestsSent.contains(queueId))
         {
@@ -143,10 +143,10 @@ namespace PMP::Client
 
     void QueueEntryInfoStorageImpl::receivedQueueEntryHash(quint32 queueID,
                                                            QueueEntryType type,
-                                                           FileHash hash)
+                                                           LocalHashId hashId)
     {
         qDebug() << "QueueEntryInfoStorageImpl: received hash for QID" << queueID << ":"
-                 << hash;
+                 << hashId;
 
         _hashRequestsSent.remove(queueID);
 
@@ -158,13 +158,13 @@ namespace PMP::Client
         }
         else
         {
-            if (info->type() == type && info->hash() == hash)
+            if (info->type() == type && info->hashId() == hashId)
             {
                 return; /* no change */
             }
         }
 
-        info->setHash(type, hash);
+        info->setHash(type, hashId);
 
         enqueueTrackChangeNotification(queueID);
     }

--- a/src/client/queueentryinfostorageimpl.h
+++ b/src/client/queueentryinfostorageimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -48,7 +48,8 @@ namespace PMP::Client
         void connected();
         void connectionBroken();
 
-        void receivedQueueEntryHash(quint32 queueID, QueueEntryType type, FileHash hash);
+        void receivedQueueEntryHash(quint32 queueID, QueueEntryType type,
+                                    LocalHashId hashId);
         void receivedTrackInfo(quint32 queueID, QueueEntryType type,
                                qint64 lengthMilliseconds, QString title, QString artist);
         void receivedPossibleFilenames(quint32 queueID, QList<QString> names);
@@ -66,6 +67,5 @@ namespace PMP::Client
         QSet<quint32> _infoRequestsSent;
         QSet<quint32> _hashRequestsSent;
     };
-
 }
 #endif

--- a/src/client/queuehashesmonitor.h
+++ b/src/client/queuehashesmonitor.h
@@ -20,7 +20,7 @@
 #ifndef PMP_CLIENT_QUEUEHASHESMONITOR_H
 #define PMP_CLIENT_QUEUEHASHESMONITOR_H
 
-#include "common/filehash.h"
+#include "localhashid.h"
 
 #include <QHash>
 #include <QList>
@@ -39,10 +39,10 @@ namespace PMP::Client
         QueueHashesMonitor(QObject* parent, AbstractQueueMonitor* queueMonitor,
                            QueueEntryInfoStorage* queueEntryInfoStorage);
 
-        bool isPresentInQueue(FileHash hash) const;
+        bool isPresentInQueue(LocalHashId hashId) const;
 
     Q_SIGNALS:
-        void hashInQueuePresenceChanged(FileHash hash);
+        void hashInQueuePresenceChanged(LocalHashId hashId);
 
     private Q_SLOTS:
         void onQueueResetted(int queueLength);
@@ -52,13 +52,13 @@ namespace PMP::Client
         void onTracksChanged(QList<quint32> queueIds);
 
     private:
-        void associateHashWithQueueId(FileHash const& hash, quint32 queueId, bool canAdd);
+        void associateHashWithQueueId(LocalHashId hashId, quint32 queueId, bool canAdd);
         void disassociateHashFromQueueId(quint32 queueId, bool canRemove);
 
         AbstractQueueMonitor* _queueMonitor;
         QueueEntryInfoStorage* _queueEntryInfoStorage;
-        QHash<FileHash, QSet<quint32>> _hashToQueueIds;
-        QHash<quint32, FileHash> _queueIdToHash;
+        QHash<LocalHashId, QSet<quint32>> _hashToQueueIds;
+        QHash<quint32, LocalHashId> _queueIdToHash;
     };
 }
 #endif

--- a/src/client/serverconnection.h
+++ b/src/client/serverconnection.h
@@ -20,7 +20,6 @@
 #ifndef PMP_CLIENT_SERVERCONNECTION_H
 #define PMP_CLIENT_SERVERCONNECTION_H
 
-#include "common/collectiontrackinfo.h"
 #include "common/disconnectreason.h"
 #include "common/future.h"
 #include "common/networkprotocol.h"
@@ -34,6 +33,9 @@
 #include "common/userloginerror.h"
 #include "common/userregistrationerror.h"
 #include "common/versioninfo.h"
+
+#include "collectiontrackinfo.h"
+#include "localhashid.h"
 
 #include <QByteArray>
 #include <QDateTime>
@@ -113,7 +115,7 @@ namespace PMP::Client
         SimpleFuture<ResultMessageErrorCode> activateDelayedStart(
                                                                 qint64 delayMilliseconds);
         SimpleFuture<ResultMessageErrorCode> deactivateDelayedStart();
-        RequestID insertQueueEntryAtIndex(FileHash const& hash, quint32 index);
+        RequestID insertQueueEntryAtIndex(LocalHashId hashId, quint32 index);
         RequestID insertSpecialQueueItemAtIndex(SpecialQueueItemType itemType, int index,
                                        QueueIndexType indexType = QueueIndexType::Normal);
         RequestID duplicateQueueEntry(uint queueID);
@@ -151,15 +153,15 @@ namespace PMP::Client
         void deleteQueueEntry(uint queueID);
         void moveQueueEntry(uint queueID, qint16 offsetDiff);
 
-        void insertQueueEntryAtFront(FileHash const& hash);
-        void insertQueueEntryAtEnd(FileHash const& hash);
+        void insertQueueEntryAtFront(LocalHashId hashId);
+        void insertQueueEntryAtEnd(LocalHashId hashId);
 
         void sendQueueEntryInfoRequest(uint queueID);
         void sendQueueEntryInfoRequest(QList<uint> const& queueIDs);
 
         void sendQueueEntryHashRequest(QList<uint> const& queueIDs);
 
-        void sendHashUserDataRequest(quint32 userId, QList<FileHash> const& hashes);
+        void sendHashUserDataRequest(quint32 userId, QList<LocalHashId> const& hashes);
 
         void sendPossibleFilenamesRequest(uint queueID);
 
@@ -213,8 +215,9 @@ namespace PMP::Client
         void queueEntryMoved(qint32 fromOffset, qint32 toOffset, quint32 queueId);
         void receivedTrackInfo(quint32 queueId, QueueEntryType type,
                                qint64 lengthMilliseconds, QString title, QString artist);
-        void receivedQueueEntryHash(quint32 queueId, QueueEntryType type, FileHash hash);
-        void receivedHashUserData(FileHash hash, quint32 userId,
+        void receivedQueueEntryHash(quint32 queueId, QueueEntryType type,
+                                    LocalHashId hashId);
+        void receivedHashUserData(LocalHashId hashId, quint32 userId,
                                   QDateTime previouslyHeard, qint16 scorePermillage);
         void receivedPossibleFilenames(quint32 queueId, QList<QString> names);
 
@@ -231,9 +234,10 @@ namespace PMP::Client
         void fullIndexationStarted();
         void fullIndexationFinished();
 
-        void collectionTracksAvailabilityChanged(QVector<PMP::FileHash> available,
-                                                 QVector<PMP::FileHash> unavailable);
-        void collectionTracksChanged(QVector<PMP::CollectionTrackInfo> changes);
+        void collectionTracksAvailabilityChanged(
+                                           QVector<PMP::Client::LocalHashId> available,
+                                           QVector<PMP::Client::LocalHashId> unavailable);
+        void collectionTracksChanged(QVector<PMP::Client::CollectionTrackInfo> changes);
 
     private Q_SLOTS:
         void onConnected();

--- a/src/client/serverconnection.h
+++ b/src/client/serverconnection.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,8 +17,8 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_SERVERCONNECTION_H
-#define PMP_SERVERCONNECTION_H
+#ifndef PMP_CLIENT_SERVERCONNECTION_H
+#define PMP_CLIENT_SERVERCONNECTION_H
 
 #include "common/collectiontrackinfo.h"
 #include "common/disconnectreason.h"
@@ -50,6 +50,7 @@ QT_FORWARD_DECLARE_CLASS(QTimer)
 namespace PMP::Client
 {
     class CollectionFetcher;
+    class LocalHashIdRepository;
     class ServerCapabilities;
     class ServerCapabilitiesImpl;
 
@@ -84,10 +85,13 @@ namespace PMP::Client
         class DuplicationResultHandler;
 
     public:
-        explicit ServerConnection(QObject* parent = nullptr,
+        explicit ServerConnection(QObject* parent,
+                                  LocalHashIdRepository* hashIdRepository,
                                   ServerEventSubscription eventSubscription =
                                                       ServerEventSubscription::AllEvents);
         ~ServerConnection();
+
+        LocalHashIdRepository* hashIdRepository() const { return _hashIdRepository; }
 
         void connectToHost(QString const& host, quint16 port);
         void disconnect();
@@ -346,6 +350,7 @@ namespace PMP::Client
         static const int KeepAliveIntervalMs;
         static const int KeepAliveReplyTimeoutMs;
 
+        LocalHashIdRepository* _hashIdRepository;
         ServerCapabilitiesImpl* _serverCapabilities;
         DisconnectReason _disconnectReason;
         QElapsedTimer _timeSinceLastMessageReceived;

--- a/src/client/serverdiscoverer.h
+++ b/src/client/serverdiscoverer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -32,6 +32,7 @@ QT_FORWARD_DECLARE_CLASS(QUdpSocket)
 
 namespace PMP::Client
 {
+    class LocalHashIdRepository;
     class ServerConnection;
     class ServerProbe;
 
@@ -71,6 +72,7 @@ namespace PMP::Client
             QString name;
         };
 
+        LocalHashIdRepository* _localHashIdRepository;
         QList<QHostAddress> _localHostNetworkAddresses;
         QUdpSocket* _socket;
         QSet<QPair<QHostAddress, quint16>> _addressesBeingProbed;
@@ -82,7 +84,8 @@ namespace PMP::Client
     {
         Q_OBJECT
     public:
-        ServerProbe(QObject* parent, QHostAddress const& address, quint16 port);
+        ServerProbe(QObject* parent, QHostAddress const& address, quint16 port,
+                    LocalHashIdRepository* localHashIdRepository);
 
     Q_SIGNALS:
         void foundServer(QHostAddress address, quint16 port,

--- a/src/client/serverinterface.cpp
+++ b/src/client/serverinterface.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -66,6 +66,11 @@ namespace PMP::Client
             },
             Qt::QueuedConnection
         );
+    }
+
+    LocalHashIdRepository* ServerInterface::hashIdRepository() const
+    {
+        return _connection->hashIdRepository();
     }
 
     AuthenticationController& ServerInterface::authenticationController()

--- a/src/client/serverinterface.h
+++ b/src/client/serverinterface.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -31,11 +31,12 @@ namespace PMP::Client
     class DynamicModeController;
     class GeneralController;
     class HistoryController;
-    class ServerConnection;
+    class LocalHashIdRepository;
     class PlayerController;
     class QueueController;
     class QueueEntryInfoFetcher;
     class QueueEntryInfoStorage;
+    class ServerConnection;
     class UserDataFetcher;
 
     class ServerInterface : public QObject
@@ -43,6 +44,8 @@ namespace PMP::Client
         Q_OBJECT
     public:
         explicit ServerInterface(ServerConnection* connection);
+
+        LocalHashIdRepository* hashIdRepository() const;
 
         AuthenticationController& authenticationController();
 

--- a/src/client/userdatafetcher.h
+++ b/src/client/userdatafetcher.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,11 +17,10 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_USERDATAFETCHER_H
-#define PMP_USERDATAFETCHER_H
+#ifndef PMP_CLIENT_USERDATAFETCHER_H
+#define PMP_CLIENT_USERDATAFETCHER_H
 
-#include "common/collectiontrackinfo.h"
-#include "common/filehash.h"
+#include "collectiontrackinfo.h"
 
 #include <QDateTime>
 #include <QHash>
@@ -45,16 +44,16 @@ namespace PMP::Client
 
         void enableAutoFetchForUser(quint32 userId);
 
-        HashData const* getHashDataForUser(quint32 userId, FileHash const& hash);
+        HashData const* getHashDataForUser(quint32 userId, LocalHashId hashId);
 
     Q_SIGNALS:
         void dataReceivedForUser(quint32 userId);
-        void userTrackDataChanged(quint32 userId, FileHash hash);
+        void userTrackDataChanged(quint32 userId, LocalHashId hashId);
 
     private Q_SLOTS:
         //void connected();
         void onNewTrackReceived(CollectionTrackInfo track);
-        void receivedHashUserData(FileHash hash, quint32 userId,
+        void receivedHashUserData(LocalHashId hashId, quint32 userId,
                                   QDateTime previouslyHeard, qint16 scorePermillage);
         void sendPendingRequests();
         void sendPendingNotifications();
@@ -76,32 +75,32 @@ namespace PMP::Client
                 _autoFetchEnabled = newValue;
             }
 
-            HashData& getOrCreateHash(FileHash const& hash) { return _hashes[hash]; }
+            HashData& getOrCreateHash(LocalHashId hashId) { return _hashes[hashId]; }
 
-            bool haveHash(FileHash const& hash) const
+            bool haveHash(LocalHashId hashId) const
             {
-                return _hashes.contains(hash);
+                return _hashes.contains(hashId);
             }
 
-            HashData const* getHash(FileHash const& hash) const
+            HashData const* getHash(LocalHashId hashId) const
             {
-                auto it = _hashes.find(hash);
+                auto it = _hashes.find(hashId);
                 if (it == _hashes.constEnd()) return nullptr;
 
                 return &it.value();
             }
 
         private:
-            QHash<FileHash, HashData> _hashes;
+            QHash<LocalHashId, HashData> _hashes;
             bool _autoFetchEnabled;
         };
 
-        void needToRequestData(quint32 userId, FileHash const& hash);
+        void needToRequestData(quint32 userId, LocalHashId hashId);
 
         CollectionWatcher* _collectionWatcher;
         ServerConnection* _connection;
         QHash<quint32, UserData> _userData;
-        QHash<quint32, QSet<FileHash> > _hashesToFetchForUsers;
+        QHash<quint32, QSet<LocalHashId>> _hashesToFetchForUsers;
         QSet<quint32> _pendingNotificationsUsers;
     };
 

--- a/src/cmd-remote/commandlineclient.cpp
+++ b/src/cmd-remote/commandlineclient.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -19,6 +19,7 @@
 
 #include "commandlineclient.h"
 
+#include "client/localhashidrepository.h"
 #include "client/serverconnection.h"
 #include "client/serverinterface.h"
 
@@ -41,6 +42,7 @@ namespace PMP
        _port(port),
        _username(username),
        _password(password),
+       _hashIdRepository(new LocalHashIdRepository()),
        _serverConnection(nullptr),
        _serverInterface(nullptr),
        _command(command),
@@ -48,7 +50,9 @@ namespace PMP
     {
         // TODO : don't subscribe to _all_ events anymore
         _serverConnection =
-                new ServerConnection(this, ServerEventSubscription::AllEvents);
+                new ServerConnection(this,
+                                     _hashIdRepository,
+                                     ServerEventSubscription::AllEvents);
         _serverInterface = new ServerInterface(_serverConnection);
 
         connect(
@@ -128,6 +132,11 @@ namespace PMP
                 Q_EMIT exitClient(resultCode);
             }
         );
+    }
+
+    CommandlineClient::~CommandlineClient()
+    {
+        delete _hashIdRepository;
     }
 
     void CommandlineClient::start()

--- a/src/cmd-remote/commandlineclient.h
+++ b/src/cmd-remote/commandlineclient.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -30,6 +30,7 @@ QT_FORWARD_DECLARE_CLASS(QTextStream)
 
 namespace PMP::Client
 {
+    class LocalHashIdRepository;
     class ServerConnection;
     class ServerInterface;
 }
@@ -45,6 +46,8 @@ namespace PMP
         CommandlineClient(QObject* parent, QTextStream* out, QTextStream* err,
                QString server, quint16 port, QString username, QString password,
                Command* command);
+
+        ~CommandlineClient();
 
     public Q_SLOTS:
         void start();
@@ -65,6 +68,7 @@ namespace PMP
         quint16 _port;
         QString _username;
         QString _password;
+        Client::LocalHashIdRepository* _hashIdRepository;
         QPointer<Client::ServerConnection> _serverConnection;
         QPointer<Client::ServerInterface> _serverInterface;
         QPointer<Command> _command;

--- a/src/common/commonmetatypes.cpp
+++ b/src/common/commonmetatypes.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -18,7 +18,6 @@
 */
 
 #include "audiodata.h"
-#include "collectiontrackinfo.h"
 #include "filehash.h"
 #include "playerhistorytrackinfo.h"
 #include "playermode.h"
@@ -43,7 +42,6 @@ namespace PMP
         CommonMetatypesInit()
         {
             qRegisterMetaType<PMP::AudioData>();
-            qRegisterMetaType<PMP::CollectionTrackInfo>();
             qRegisterMetaType<PMP::FileHash>();
             qRegisterMetaType<PMP::PlayerHistoryTrackInfo>();
             qRegisterMetaType<PMP::PlayerMode>();

--- a/src/gui-remote/collectiontablemodel.h
+++ b/src/gui-remote/collectiontablemodel.h
@@ -20,8 +20,9 @@
 #ifndef PMP_COLLECTIONTABLEMODEL_H
 #define PMP_COLLECTIONTABLEMODEL_H
 
-#include "common/collectiontrackinfo.h"
 #include "common/playerstate.h"
+
+#include "client/collectiontrackinfo.h"
 
 #include "trackjudge.h"
 
@@ -34,6 +35,7 @@
 
 namespace PMP::Client
 {
+    class LocalHashIdRepository;
     class QueueHashesMonitor;
     class ServerInterface;
     class UserDataFetcher;
@@ -74,8 +76,8 @@ namespace PMP
         int sortColumn() const;
         Qt::SortOrder sortOrder() const;
 
-        CollectionTrackInfo* trackAt(const QModelIndex& index) const;
-        CollectionTrackInfo* trackAt(int rowIndex) const;
+        Client::CollectionTrackInfo* trackAt(const QModelIndex& index) const;
+        Client::CollectionTrackInfo* trackAt(int rowIndex) const;
 
         int rowCount(const QModelIndex& parent = QModelIndex()) const;
         int columnCount(const QModelIndex& parent = QModelIndex()) const;
@@ -91,57 +93,58 @@ namespace PMP
         void setHighlightColorIndex(int colorIndex);
 
     private Q_SLOTS:
-        void onNewTrackReceived(CollectionTrackInfo track);
-        void onTrackAvailabilityChanged(FileHash hash, bool isAvailable);
-        void onTrackDataChanged(CollectionTrackInfo track);
-        void onUserTrackDataChanged(quint32 userId, FileHash hash);
-        void currentTrackInfoChanged(FileHash hash);
-        void onHashInQueuePresenceChanged(FileHash hash);
+        void onNewTrackReceived(Client::CollectionTrackInfo track);
+        void onTrackAvailabilityChanged(Client::LocalHashId hashId, bool isAvailable);
+        void onTrackDataChanged(Client::CollectionTrackInfo track);
+        void onUserTrackDataChanged(quint32 userId, Client::LocalHashId hashId);
+        void currentTrackInfoChanged(Client::LocalHashId hashId);
+        void onHashInQueuePresenceChanged(Client::LocalHashId hashId);
 
     private:
-        void updateTrackAvailability(FileHash hash, bool isAvailable);
+        void updateTrackAvailability(Client::LocalHashId hashId, bool isAvailable);
         template<class T> void addWhenModelEmpty(T trackCollection);
-        void addOrUpdateTrack(CollectionTrackInfo const& track);
-        void addTrack(CollectionTrackInfo const& track);
-        void updateTrack(int innerIndex, CollectionTrackInfo const& newTrackData);
+        void addOrUpdateTrack(Client::CollectionTrackInfo const& track);
+        void addTrack(Client::CollectionTrackInfo const& track);
+        void updateTrack(int innerIndex, Client::CollectionTrackInfo const& newTrackData);
         void buildIndexMaps();
         void rebuildInnerMap(int outerStartIndex = 0);
         void rebuildInnerMap(int outerStartIndex, int outerEndIndex);
-        int findOuterIndexMapIndexForInsert(CollectionTrackInfo const& track);
-        int findOuterIndexMapIndexForInsert(CollectionTrackInfo const& track,
+        int findOuterIndexMapIndexForInsert(Client::CollectionTrackInfo const& track);
+        int findOuterIndexMapIndexForInsert(Client::CollectionTrackInfo const& track,
                                             int searchRangeBegin, int searchRangeEnd);
-        int findOuterIndexForHash(FileHash const& hash);
+        int findOuterIndexForHash(Client::LocalHashId hashId);
         void markLeftColumnAsChanged();
         void markEverythingAsChanged();
 
         bool lessThan(int index1, int index2) const;
-        bool lessThan(CollectionTrackInfo const& track1,
-                      CollectionTrackInfo const& track2) const;
+        bool lessThan(Client::CollectionTrackInfo const& track1,
+                      Client::CollectionTrackInfo const& track2) const;
 
         int compareStrings(const QString& s1, const QString& s2,
                            Qt::SortOrder sortOrder) const;
 
-        int compareTracks(const CollectionTrackInfo& track1,
-                          const CollectionTrackInfo& track2) const;
+        int compareTracks(const Client::CollectionTrackInfo& track1,
+                          const Client::CollectionTrackInfo& track2) const;
 
-        int compareTitles(const CollectionTrackInfo& track1,
-                          const CollectionTrackInfo& track2,
+        int compareTitles(const Client::CollectionTrackInfo& track1,
+                          const Client::CollectionTrackInfo& track2,
                           Qt::SortOrder sortOrder) const;
 
-        int compareArtists(const CollectionTrackInfo& track1,
-                           const CollectionTrackInfo& track2,
+        int compareArtists(const Client::CollectionTrackInfo& track1,
+                           const Client::CollectionTrackInfo& track2,
                            Qt::SortOrder sortOrder) const;
 
-        int compareLengths(const CollectionTrackInfo& track1,
-                           const CollectionTrackInfo& track2,
+        int compareLengths(const Client::CollectionTrackInfo& track1,
+                           const Client::CollectionTrackInfo& track2,
                            Qt::SortOrder sortOrder) const;
 
-        int compareAlbums(const CollectionTrackInfo& track1,
-                          const CollectionTrackInfo& track2,
+        int compareAlbums(const Client::CollectionTrackInfo& track1,
+                          const Client::CollectionTrackInfo& track2,
                           Qt::SortOrder sortOrder) const;
 
-        QVector<CollectionTrackInfo*> _tracks;
-        QHash<FileHash, int> _hashesToInnerIndexes;
+        Client::LocalHashIdRepository* _hashIdRepository;
+        QVector<Client::CollectionTrackInfo*> _tracks;
+        QHash<Client::LocalHashId, int> _hashesToInnerIndexes;
         QVector<int> _innerToOuterIndexMap;
         QVector<int> _outerToInnerIndexMap;
         QCollator _collator;
@@ -149,7 +152,7 @@ namespace PMP
         int _sortBy;
         Qt::SortOrder _sortOrder;
         TrackJudge _highlightingTrackJudge;
-        FileHash _currentTrackHash;
+        Client::LocalHashId _currentTrackHash;
         PlayerState _playerState;
         Client::QueueHashesMonitor* _queueHashesMonitor;
     };
@@ -168,7 +171,7 @@ namespace PMP
 
         virtual void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
 
-        CollectionTrackInfo* trackAt(const QModelIndex& index) const;
+        Client::CollectionTrackInfo* trackAt(const QModelIndex& index) const;
 
     public Q_SLOTS:
         void setSearchText(QString search);

--- a/src/gui-remote/collectionwidget.cpp
+++ b/src/gui-remote/collectionwidget.cpp
@@ -169,7 +169,7 @@ namespace PMP
         if (!trackPointer) return;
 
         auto track = *trackPointer;
-        FileHash hash = track.hash();
+        auto hashId = track.hashId();
 
         if (_collectionContextMenu)
             delete _collectionContextMenu;
@@ -180,9 +180,10 @@ namespace PMP
         connect(
             enqueueFrontAction, &QAction::triggered,
             this,
-            [this, hash]() {
+            [this, hashId]()
+            {
                 qDebug() << "collection context menu: enqueue (front) triggered";
-                _serverInterface->queueController().insertQueueEntryAtFront(hash);
+                _serverInterface->queueController().insertQueueEntryAtFront(hashId);
             }
         );
 
@@ -191,9 +192,10 @@ namespace PMP
         connect(
             enqueueEndAction, &QAction::triggered,
             this,
-            [this, hash]() {
+            [this, hashId]()
+            {
                 qDebug() << "collection context menu: enqueue (end) triggered";
-                _serverInterface->queueController().insertQueueEntryAtEnd(hash);
+                _serverInterface->queueController().insertQueueEntryAtEnd(hashId);
             }
         );
 

--- a/src/gui-remote/mainwidget.cpp
+++ b/src/gui-remote/mainwidget.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -378,8 +378,8 @@ namespace PMP
         }
 
         int row = index.row();
-        auto hash = _historyModel->trackHashAt(row);
-        if (hash.isNull())
+        auto hashId = _historyModel->trackHashAt(row);
+        if (hashId.isZero())
         {
             qDebug() << "history: no hash known for track at row" << row;
             return;
@@ -394,10 +394,10 @@ namespace PMP
         connect(
             enqueueFrontAction, &QAction::triggered,
             this,
-            [this, hash]()
+            [this, hashId]()
             {
                 qDebug() << "history context menu: enqueue (front) triggered";
-                _serverInterface->queueController().insertQueueEntryAtFront(hash);
+                _serverInterface->queueController().insertQueueEntryAtFront(hashId);
             }
         );
 
@@ -405,10 +405,10 @@ namespace PMP
         connect(
             enqueueEndAction, &QAction::triggered,
             this,
-            [this, hash]()
+            [this, hashId]()
             {
                 qDebug() << "history context menu: enqueue (end) triggered";
-                _serverInterface->queueController().insertQueueEntryAtEnd(hash);
+                _serverInterface->queueController().insertQueueEntryAtEnd(hashId);
             }
         );
 
@@ -418,10 +418,10 @@ namespace PMP
         connect(
             trackInfoAction, &QAction::triggered,
             this,
-            [this, hash]()
+            [this, hashId]()
             {
                 qDebug() << "history context menu: track info triggered";
-                showTrackInfoDialog(hash);
+                showTrackInfoDialog(hashId);
             }
         );
 
@@ -598,7 +598,7 @@ namespace PMP
         _queueContextMenu->addSeparator();
 
         QAction* trackInfoAction = _queueContextMenu->addAction(tr("Track info"));
-        if (track.hash().isNull())
+        if (track.hashId().isZero())
         {
             trackInfoAction->setEnabled(false);
         }
@@ -612,7 +612,7 @@ namespace PMP
                     qDebug() << "queue context menu: track info action triggered for item"
                              << track.queueId();
 
-                    showTrackInfoDialog(track.hash(), track.queueId());
+                    showTrackInfoDialog(track.hashId(), track.queueId());
                 }
             );
         }
@@ -783,7 +783,8 @@ namespace PMP
         auto& currentTrackMonitor = _serverInterface->currentTrackMonitor();
 
         auto hash = currentTrackMonitor.currentTrackHash();
-        if (hash.isNull()) return;
+        if (hash.isZero())
+            return;
 
         showTrackInfoDialog(hash, currentTrackMonitor.currentQueueId());
     }
@@ -853,7 +854,7 @@ namespace PMP
     void MainWidget::enableDisableTrackInfoButton()
     {
         bool haveTrackHash =
-               !_serverInterface->currentTrackMonitor().currentTrackHash().isNull();
+               !_serverInterface->currentTrackMonitor().currentTrackHash().isZero();
 
         _ui->trackInfoButton->setEnabled(haveTrackHash);
     }
@@ -907,9 +908,9 @@ namespace PMP
         _ui->positionValueLabel->setText(text);
     }
 
-    void MainWidget::showTrackInfoDialog(FileHash hash, quint32 queueId)
+    void MainWidget::showTrackInfoDialog(LocalHashId hashId, quint32 queueId)
     {
-        auto dialog = new TrackInfoDialog(this, _serverInterface, hash, queueId);
+        auto dialog = new TrackInfoDialog(this, _serverInterface, hashId, queueId);
         connect(dialog, &QDialog::finished, dialog, &QDialog::deleteLater);
         dialog->open();
     }

--- a/src/gui-remote/mainwidget.h
+++ b/src/gui-remote/mainwidget.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,8 +20,9 @@
 #ifndef PMP_MAINWIDGET_H
 #define PMP_MAINWIDGET_H
 
-#include "common/filehash.h"
 #include "common/playerstate.h"
+
+#include "client/localhashid.h"
 
 #include <QWidget>
 
@@ -91,7 +92,7 @@ namespace PMP
         void updateTrackTimeDisplay(qint64 positionInMilliseconds,
                                     qint64 trackLengthInMilliseconds);
 
-        void showTrackInfoDialog(FileHash hash, quint32 queueId = 0);
+        void showTrackInfoDialog(Client::LocalHashId hashId, quint32 queueId = 0);
 
         bool keyEventFilter(QKeyEvent* event);
 

--- a/src/gui-remote/mainwindow.cpp
+++ b/src/gui-remote/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include "common/version.h"
 
 #include "client/generalcontroller.h"
+#include "client/localhashidrepository.h"
 #include "client/playercontroller.h"
 #include "client/queuehashesmonitor.h"
 #include "client/serverconnection.h"
@@ -66,6 +67,7 @@ namespace PMP
        _rightStatus(nullptr),
        _leftStatusTimer(new QTimer(this)),
        _connectionWidget(new ConnectionWidget(this)),
+       _hashIdRepository(new LocalHashIdRepository()),
        _connection(nullptr),
        _serverInterface(nullptr),
        _userPickerWidget(nullptr),
@@ -121,7 +123,7 @@ namespace PMP
 
     MainWindow::~MainWindow()
     {
-        //
+        delete _hashIdRepository;
     }
 
     void MainWindow::createActions()
@@ -505,7 +507,7 @@ namespace PMP
 
     void MainWindow::onDoConnect(QString server, uint port)
     {
-        _connection = new ServerConnection(this);
+        _connection = new ServerConnection(this, _hashIdRepository);
         _serverInterface = new ServerInterface(_connection);
 
         auto* generalController = &_serverInterface->generalController();

--- a/src/gui-remote/mainwindow.h
+++ b/src/gui-remote/mainwindow.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -33,6 +33,7 @@ QT_FORWARD_DECLARE_CLASS(QTimer)
 
 namespace PMP::Client
 {
+    class LocalHashIdRepository;
     class ServerConnection;
     class ServerInterface;
 }
@@ -104,6 +105,7 @@ namespace PMP
         QTimer* _leftStatusTimer;
 
         ConnectionWidget* _connectionWidget;
+        Client::LocalHashIdRepository* _hashIdRepository;
         Client::ServerConnection* _connection;
         Client::ServerInterface* _serverInterface;
         UserPickerWidget* _userPickerWidget;

--- a/src/gui-remote/playerhistorymodel.h
+++ b/src/gui-remote/playerhistorymodel.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2017-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,8 +20,9 @@
 #ifndef PMP_PLAYERHISTORYMODEL_H
 #define PMP_PLAYERHISTORYMODEL_H
 
-#include "common/filehash.h"
 #include "common/playerhistorytrackinfo.h"
+
+#include "client/localhashid.h"
 
 #include <QAbstractTableModel>
 #include <QList>
@@ -30,6 +31,7 @@
 
 namespace PMP::Client
 {
+    class LocalHashIdRepository;
     class QueueEntryInfoStorage;
     class ServerInterface;
 }
@@ -42,7 +44,7 @@ namespace PMP
     public:
         PlayerHistoryModel(QObject* parent, Client::ServerInterface* serverInterface);
 
-        FileHash trackHashAt(int rowIndex) const;
+        Client::LocalHashId trackHashAt(int rowIndex) const;
 
         int rowCount(const QModelIndex& parent = QModelIndex()) const;
         int columnCount(const QModelIndex& parent = QModelIndex()) const;
@@ -63,6 +65,7 @@ namespace PMP
 
     private:
         int _historySizeGoal;
+        Client::LocalHashIdRepository* _hashIdRepository;
         Client::QueueEntryInfoStorage* _infoStorage;
         qint64 _clientClockTimeOffsetMs;
         QList<QSharedPointer<PlayerHistoryTrackInfo>> _list;

--- a/src/gui-remote/queuemediator.cpp
+++ b/src/gui-remote/queuemediator.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -441,9 +441,9 @@ namespace PMP
         moveTrack(fromIndex, toIndex, queueId);
     }
 
-    void QueueMediator::insertFileAsync(int index, const FileHash& hash)
+    void QueueMediator::insertFileAsync(int index, LocalHashId hashId)
     {
-        queueController().insertQueueEntryAtIndex(hash, index);
+        queueController().insertQueueEntryAtIndex(hashId, index);
     }
 
     void QueueMediator::duplicateEntryAsync(quint32 queueID)

--- a/src/gui-remote/queuemediator.h
+++ b/src/gui-remote/queuemediator.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,6 +21,7 @@
 #define PMP_QUEUEMEDIATOR_H
 
 #include "client/abstractqueuemonitor.h"
+#include "client/localhashid.h"
 
 namespace PMP::Client
 {
@@ -31,8 +32,6 @@ namespace PMP::Client
 
 namespace PMP
 {
-    class FileHash;
-
     class QueueMediator : public Client::AbstractQueueMonitor
     {
         Q_OBJECT
@@ -53,7 +52,7 @@ namespace PMP
         void moveTrack(int fromIndex, int toIndex, quint32 queueID);
         void moveTrackToEnd(int fromIndex, quint32 queueId);
 
-        void insertFileAsync(int index, const FileHash& hash);
+        void insertFileAsync(int index, Client::LocalHashId hashId);
         void duplicateEntryAsync(quint32 queueID);
         bool canDuplicateEntry(quint32 queueID) const;
 

--- a/src/gui-remote/queuemodel.h
+++ b/src/gui-remote/queuemodel.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,8 +20,9 @@
 #ifndef PMP_QUEUEMODEL_H
 #define PMP_QUEUEMODEL_H
 
-#include "common/filehash.h"
 #include "common/playermode.h"
+
+#include "client/localhashid.h"
 
 #include <QAbstractTableModel>
 #include <QHash>
@@ -32,6 +33,7 @@ QT_FORWARD_DECLARE_CLASS(QTimer)
 
 namespace PMP::Client
 {
+    class LocalHashIdRepository;
     class QueueEntryInfo;
     class QueueEntryInfoStorage;
     class ServerInterface;
@@ -80,21 +82,21 @@ namespace PMP
             //
         }
 
-        QueueTrack(quint32 queueId, const FileHash& hash)
-         : _id(queueId), _hash(hash), _real(true)
+        QueueTrack(quint32 queueId, Client::LocalHashId hashId)
+         : _id(queueId), _hashId(hashId), _real(true)
         {
             //
         }
 
         quint32 queueId() const { return _id; }
-        FileHash hash() const { return _hash; }
+        Client::LocalHashId hashId() const { return _hashId; }
 
         bool isNull() const { return _id == 0; }
         bool isRealTrack() const { return _real; }
 
     private:
         quint32 _id;
-        FileHash _hash;
+        Client::LocalHashId _hashId;
         bool _real;
     };
 
@@ -161,8 +163,7 @@ namespace PMP
         void markLastHeardColumnAsChanged();
         void markUserDataColumnsAsChanged();
 
-        //Track* trackAt(const QModelIndex& index) const;
-
+        Client::LocalHashIdRepository* _hashIdRepository;
         Client::UserDataFetcher* _userDataFetcher;
         QueueMediator* _source;
         Client::QueueEntryInfoStorage* _infoStorage;

--- a/src/gui-remote/trackinfodialog.h
+++ b/src/gui-remote/trackinfodialog.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,8 +20,7 @@
 #ifndef PMP_TRACKINFODIALOG_H
 #define PMP_TRACKINFODIALOG_H
 
-#include "common/collectiontrackinfo.h"
-#include "common/filehash.h"
+#include "client/collectiontrackinfo.h"
 
 #include <QDateTime>
 #include <QDialog>
@@ -39,25 +38,23 @@ namespace PMP::Client
 
 namespace PMP
 {
-    class FileHash;
-
     class TrackInfoDialog : public QDialog
     {
         Q_OBJECT
     public:
         TrackInfoDialog(QWidget* parent,
                         Client::ServerInterface* serverInterface,
-                        FileHash const& hash, quint32 queueId = 0);
+                        Client::LocalHashId hashId, quint32 queueId = 0);
 
         TrackInfoDialog(QWidget* parent,
                         Client::ServerInterface* serverInterface,
-                        CollectionTrackInfo const& track);
+                        Client::CollectionTrackInfo const& track);
 
         ~TrackInfoDialog();
 
     private Q_SLOTS:
-        void newTrackReceived(CollectionTrackInfo track);
-        void trackDataChanged(CollectionTrackInfo track);
+        void newTrackReceived(Client::CollectionTrackInfo track);
+        void trackDataChanged(Client::CollectionTrackInfo track);
         void dataReceivedForUser(quint32 userId);
         void updateLastHeard();
 
@@ -68,15 +65,15 @@ namespace PMP
 
         void fillQueueId();
         void fillHash();
-        void fillTrackDetails(CollectionTrackInfo const& trackInfo);
-        void fillUserData(const FileHash& hash);
+        void fillTrackDetails(Client::CollectionTrackInfo const& trackInfo);
+        void fillUserData(Client::LocalHashId hashId);
         void clearTrackDetails();
         void clearUserData();
 
         Ui::TrackInfoDialog* _ui;
         Client::ServerInterface* _serverInterface;
         QTimer* _lastHeardUpdateTimer;
-        FileHash _trackHash;
+        Client::LocalHashId _trackHashId;
         QDateTime _lastHeard;
         quint32 _queueId;
     };

--- a/src/gui-remote/trackjudge.cpp
+++ b/src/gui-remote/trackjudge.cpp
@@ -19,8 +19,11 @@
 
 #include "trackjudge.h"
 
+#include "client/collectiontrackinfo.h"
 #include "client/queuehashesmonitor.h"
 #include "client/userdatafetcher.h"
+
+using namespace PMP::Client;
 
 namespace PMP
 {
@@ -152,10 +155,10 @@ namespace PMP
                 return track.lengthInMilliseconds() >= 5 * 60 * 1000;
 
             case TrackCriterium::NotInTheQueue:
-                return !_queueHashesMonitor.isPresentInQueue(track.hash());
+                return !_queueHashesMonitor.isPresentInQueue(track.hashId());
 
             case TrackCriterium::InTheQueue:
-                return _queueHashesMonitor.isPresentInQueue(track.hash());
+                return _queueHashesMonitor.isPresentInQueue(track.hashId());
         }
 
         return false;
@@ -167,7 +170,8 @@ namespace PMP
     {
         if (!_haveUserId) return TriBool::unknown;
 
-        auto hashDataForUser = _userDataFetcher.getHashDataForUser(_userId, track.hash());
+        auto hashDataForUser =
+                _userDataFetcher.getHashDataForUser(_userId, track.hashId());
 
         if (!hashDataForUser || !hashDataForUser->scoreReceived)
             return TriBool::unknown;
@@ -181,7 +185,8 @@ namespace PMP
     {
         if (!_haveUserId) return TriBool::unknown;
 
-        auto hashDataForUser = _userDataFetcher.getHashDataForUser(_userId, track.hash());
+        auto hashDataForUser =
+                _userDataFetcher.getHashDataForUser(_userId, track.hashId());
 
         if (!hashDataForUser || !hashDataForUser->previouslyHeardReceived)
             return TriBool::unknown;

--- a/src/gui-remote/trackjudge.h
+++ b/src/gui-remote/trackjudge.h
@@ -28,14 +28,13 @@
 
 namespace PMP::Client
 {
+    class CollectionTrackInfo;
     class QueueHashesMonitor;
     class UserDataFetcher;
 }
 
 namespace PMP
 {
-    class CollectionTrackInfo;
-
     enum class TrackCriterium
     {
         AllTracks = 0,
@@ -85,23 +84,24 @@ namespace PMP
         bool criteriumUsesUserData() const;
         bool criteriumResultsInAllTracks() const;
 
-        TriBool trackSatisfiesCriteria(CollectionTrackInfo const& track) const;
+        TriBool trackSatisfiesCriteria(Client::CollectionTrackInfo const& track) const;
 
     private:
         static bool usesUserData(TrackCriterium criterium);
 
-        TriBool trackSatisfiesCriterium(CollectionTrackInfo const& track,
+        TriBool trackSatisfiesCriterium(Client::CollectionTrackInfo const& track,
                                         TrackCriterium criterium) const;
 
-        TriBool trackSatisfiesScoreCriterium(CollectionTrackInfo const& track,
+        TriBool trackSatisfiesScoreCriterium(Client::CollectionTrackInfo const& track,
                               std::function<TriBool(int)> scorePermillageEvaluator) const;
 
-        TriBool trackSatisfiesLastHeardDateCriterium(CollectionTrackInfo const& track,
+        TriBool trackSatisfiesLastHeardDateCriterium(
+                                   Client::CollectionTrackInfo const& track,
                                    std::function<TriBool(QDateTime)> dateEvaluator) const;
 
         TriBool trackSatisfiesNotHeardInTheLastXDaysCriterium(
-                                                         CollectionTrackInfo const& track,
-                                                         int days) const;
+                                                 Client::CollectionTrackInfo const& track,
+                                                 int days) const;
 
         TrackCriterium _criterium1;
         TrackCriterium _criterium2;

--- a/src/server/collectionmonitor.h
+++ b/src/server/collectionmonitor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,10 +17,10 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_COLLECTIONMONITOR_H
-#define PMP_COLLECTIONMONITOR_H
+#ifndef PMP_SERVER_COLLECTIONMONITOR_H
+#define PMP_SERVER_COLLECTIONMONITOR_H
 
-#include "common/collectiontrackinfo.h"
+#include "collectiontrackinfo.h"
 
 #include <QHash>
 #include <QMetaType>
@@ -35,7 +35,7 @@ namespace PMP::Server
     {
         Q_OBJECT
     public:
-        CollectionMonitor(QObject* parent = 0);
+        CollectionMonitor(QObject* parent = nullptr);
 
     public Q_SLOTS:
         void hashBecameAvailable(PMP::FileHash hash);
@@ -46,7 +46,7 @@ namespace PMP::Server
     Q_SIGNALS:
         void hashAvailabilityChanged(QVector<PMP::FileHash> available,
                                      QVector<PMP::FileHash> unavailable);
-        void hashInfoChanged(QVector<PMP::CollectionTrackInfo> changes);
+        void hashInfoChanged(QVector<PMP::Server::CollectionTrackInfo> changes);
 
     private Q_SLOTS:
         void emitNotifications();
@@ -56,7 +56,8 @@ namespace PMP::Server
         void emitFullNotifications(QVector<FileHash> hashes);
         void emitAvailabilityNotifications(QVector<FileHash> hashes);
 
-        struct HashInfo {
+        struct HashInfo
+        {
             bool isAvailable;
             QString title, artist, album;
             qint32 lengthInMilliseconds;
@@ -68,7 +69,8 @@ namespace PMP::Server
             }
         };
 
-        struct Changed {
+        struct Changed
+        {
             bool availability;
             bool tags;
 

--- a/src/server/collectiontrackinfo.h
+++ b/src/server/collectiontrackinfo.h
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_SERVER_COLLECTIONTRACKINFO_H
+#define PMP_SERVER_COLLECTIONTRACKINFO_H
+
+#include "common/filehash.h"
+
+#include <QMetaType>
+#include <QString>
+
+namespace PMP::Server
+{
+    class CollectionTrackInfo
+    {
+    public:
+        CollectionTrackInfo()
+         : _isAvailable(false), _lengthInMs(-1)
+        {
+            //
+        }
+
+        CollectionTrackInfo(FileHash const& hash, bool isAvailable)
+         : _hash(hash), _isAvailable(isAvailable), _lengthInMs(-1)
+        {
+            //
+        }
+
+        CollectionTrackInfo(FileHash const& hash, bool isAvailable,
+                            QString const& title, QString const& artist,
+                            QString const& album, qint32 lengthInMilliseconds)
+         : _hash(hash), _isAvailable(isAvailable), _lengthInMs(lengthInMilliseconds),
+           _title(title), _artist(artist), _album(album)
+        {
+            //
+        }
+
+        const FileHash& hash() const { return _hash; }
+
+        void setAvailable(bool available) { _isAvailable = available; }
+        bool isAvailable() const { return _isAvailable; }
+
+        const QString& title() const { return _title; }
+        const QString& artist() const { return _artist; }
+        const QString& album() const { return _album; }
+        bool lengthIsKnown() const { return _lengthInMs >= 0; }
+        qint32 lengthInMilliseconds() const { return _lengthInMs; }
+
+        qint32 lengthInSeconds() const
+        {
+            return lengthIsKnown() ? _lengthInMs / 1000 : -1;
+        }
+
+        bool titleAndArtistUnknown() const
+        {
+            return _title.isEmpty() && _artist.isEmpty();
+        }
+
+    private:
+        FileHash _hash;
+        bool _isAvailable;
+        qint32 _lengthInMs;
+        QString _title, _artist, _album;
+    };
+
+    inline bool operator==(const CollectionTrackInfo& me,
+                           const CollectionTrackInfo& other)
+    {
+        return me.hash() == other.hash()
+            && me.isAvailable() == other.isAvailable()
+            && me.lengthInMilliseconds() == other.lengthInMilliseconds()
+            && me.title() == other.title()
+            && me.artist() == other.artist()
+            && me.album() == other.album();
+    }
+
+    inline bool operator!=(const CollectionTrackInfo& me,
+                           const CollectionTrackInfo& other)
+    {
+        return !(me == other);
+    }
+}
+
+Q_DECLARE_METATYPE(PMP::Server::CollectionTrackInfo)
+
+#endif

--- a/src/server/connectedclient.h
+++ b/src/server/connectedclient.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,14 +17,14 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_CONNECTEDCLIENT_H
-#define PMP_CONNECTEDCLIENT_H
+#ifndef PMP_SERVER_CONNECTEDCLIENT_H
+#define PMP_SERVER_CONNECTEDCLIENT_H
 
-#include "common/collectiontrackinfo.h"
 #include "common/filehash.h"
 #include "common/networkprotocol.h"
 #include "common/startstopeventstatus.h"
 
+#include "collectiontrackinfo.h"
 #include "hashstats.h"
 #include "playerhistoryentry.h"
 #include "result.h"
@@ -256,6 +256,5 @@ namespace PMP::Server
         QVector<FileHash> _hashes;
         int _currentIndex;
     };
-
 }
 #endif

--- a/src/server/resolver.h
+++ b/src/server/resolver.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,16 +17,16 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_RESOLVER_H
-#define PMP_RESOLVER_H
+#ifndef PMP_SERVER_RESOLVER_H
+#define PMP_SERVER_RESOLVER_H
 
 #include "common/audiodata.h"
-#include "common/collectiontrackinfo.h"
 #include "common/filehash.h"
 #include "common/future.h"
 #include "common/tagdata.h"
 
 #include "analyzer.h"
+#include "collectiontrackinfo.h"
 
 #include <QDateTime>
 #include <QHash>

--- a/src/server/servermetatypes.cpp
+++ b/src/server/servermetatypes.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2018-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2018-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -18,6 +18,7 @@
 */
 
 #include "analyzer.h"
+#include "collectiontrackinfo.h"
 
 #include <QMetaType>
 #include <QVector>
@@ -33,6 +34,7 @@ namespace PMP::Server
         {
             qRegisterMetaType<QVector<uint>>();
 
+            qRegisterMetaType<PMP::Server::CollectionTrackInfo>();
             qRegisterMetaType<PMP::Server::FileAnalysis>();
             qRegisterMetaType<PMP::Server::FileHashes>();
             qRegisterMetaType<PMP::Server::FileInfo>();


### PR DESCRIPTION
In the client, instead of passing complete hashes around, assign each hash an ID local to the client and pass the IDs around.