### PR TITLE
Fix wrong hash in the presence of an APEv2 tag

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -25,7 +25,7 @@ KNOWN BUGS
  * when on GStreamer: InvalidMedia error "Your GStreamer installation is missing a plug-in" freezes playback
  * GUI remote: tracks can be dragged using the right mouse button (not just the left button)
  * GUI remote: tracks without title/artist info are listed as a blank line in the music collection table
- * hash calculation is wrong for MP3 files containing an APE tag
+ * hash calculation does not skip padding bytes
  * preloaded tracks are sometimes deleted before they are used because they are old
  * player fails to play preloaded entries of which the file has been deleted already
  * GUI remote: searching the music collection for "e" does not return results having "ë"


### PR DESCRIPTION
The APE tag was not stripped correctly when calculating the hash of an mp3 file. This caused the hash to be wrong for mp3 files containing an APE tag. Fortunately, the APE tag is not widely used for mp3 files.

User statistics (scores) in PMP for files that were affected by this bug should be preserved despite the hash value changing. This is because PMP already had a dual hash system for mp3 files, and the second hash should still be the same as before.