### PR TITLE
CMake improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- PMP now requires CMake 3.21 or later.
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2022, Kevin Andre <hyperquantum@gmail.com>
+# Copyright (C) 2011-2023, Kevin Andre <hyperquantum@gmail.com>
 #
 # This file is part of PMP (Party Music Player).
 #
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along
 # with PMP.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
 set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,41 +240,67 @@ if (NOT ENABLE_WIN32_CONSOLE)
   set(PMP_WIN32_FLAG WIN32)
 endif (NOT ENABLE_WIN32_CONSOLE)
 
+add_library(PmpCommon OBJECT
+    ${PMP_COMMON_SOURCES}
+    ${PMP_COMMON_MOCS}
+)
+target_link_libraries(PmpCommon Qt5::Core)
+
+add_library(PmpClient OBJECT
+    ${PMP_CLIENT_SOURCES}
+    ${PMP_CLIENT_MOCS}
+)
+target_link_libraries(PmpClient Qt5::Core Qt5::Network)
+
+add_library(PmpServer OBJECT
+    ${PMP_SERVER_SOURCES}
+    ${PMP_SERVER_MOCS}
+)
+target_link_libraries(PmpServer Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
+
 add_executable(PMP-HashTool
     tools/hash-main.cpp
-    common/audiodata.cpp
-    common/commonmetatypes.cpp
-    common/fileanalyzer.cpp
-    common/filehash.cpp
-    common/tagdata.cpp
-    common/util.cpp
+)
+target_link_libraries(PMP-HashTool
+    $<TARGET_OBJECTS:PmpCommon>
 )
 
 add_executable(quicktest
     tools/quicktest.cpp
-    ${PMP_SERVER_SOURCES} ${PMP_SERVER_MOCS}
-    ${PMP_COMMON_SOURCES} ${PMP_COMMON_MOCS}
+)
+target_link_libraries(quicktest
+    $<TARGET_OBJECTS:PmpServer>
+    $<TARGET_OBJECTS:PmpClient>
+    $<TARGET_OBJECTS:PmpCommon>
 )
 
 add_executable(PMP-Server
     server/server-main.cpp
-    ${PMP_SERVER_SOURCES} ${PMP_SERVER_MOCS}
-    ${PMP_COMMON_SOURCES} ${PMP_COMMON_MOCS}
 )
+target_link_libraries(PMP-Server
+    $<TARGET_OBJECTS:PmpServer>
+    $<TARGET_OBJECTS:PmpCommon>
+)
+
 add_executable(PMP-Cmd-Remote
     cmd-remote/cmd-remote-main.cpp
     ${PMP_CMD_REMOTE_SOURCES} ${PMP_CMD_REMOTE_MOCS}
-    ${PMP_CLIENT_SOURCES} ${PMP_CLIENT_MOCS}
-    ${PMP_COMMON_SOURCES} ${PMP_COMMON_MOCS}
 )
+target_link_libraries(PMP-Cmd-Remote
+    $<TARGET_OBJECTS:PmpClient>
+    $<TARGET_OBJECTS:PmpCommon>
+)
+
 add_executable(PMP-GUI-Remote
     ${PMP_WIN32_FLAG}
     gui-remote/gui-remote-main.cpp
     ${PMP_GUI_REMOTE_SOURCES} ${PMP_GUI_REMOTE_MOCS}
     ${PMP_GUI_REMOTE_UICS}
     ${PMP_GUI_REMOTE_QRCS}
-    ${PMP_CLIENT_SOURCES} ${PMP_CLIENT_MOCS}
-    ${PMP_COMMON_SOURCES} ${PMP_COMMON_MOCS}
+)
+target_link_libraries(PMP-GUI-Remote
+    $<TARGET_OBJECTS:PmpClient>
+    $<TARGET_OBJECTS:PmpCommon>
 )
 
 # Qt dependencies for each executable

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2022, Kevin Andre <hyperquantum@gmail.com>
+# Copyright (C) 2016-2023, Kevin Andre <hyperquantum@gmail.com>
 #
 # This file is part of PMP (Party Music Player).
 #
@@ -23,12 +23,8 @@ configure_file(${CMAKE_SOURCE_DIR}/src/common/version.h.in common/version.h)
 
 add_executable(PMP_hash_test
     hash_test.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/audiodata.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/fileanalyzer.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/filehash.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/tagdata.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/util.cpp
 )
+target_link_libraries(PMP_hash_test $<TARGET_OBJECTS:PmpCommon>)
 target_link_libraries(PMP_hash_test Qt5::Core)
 target_link_libraries(PMP_hash_test ${TAGLIB_LIBRARIES})
 
@@ -72,12 +68,10 @@ add_test(test_nullable test_nullable)
 
 # TestFileHash
 qt5_wrap_cpp(PMP_TestFileHash_MOCS test_filehash.h)
-add_executable(test_filehash test_filehash.cpp
-    ${PMP_TestFileHash_MOCS}
-    ${CMAKE_SOURCE_DIR}/src/common/filehash.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/util.cpp
-)
+add_executable(test_filehash test_filehash.cpp ${PMP_TestFileHash_MOCS})
+target_link_libraries(test_filehash $<TARGET_OBJECTS:PmpCommon>)
 target_link_libraries(test_filehash Qt5::Core Qt5::Test)
+target_link_libraries(test_filehash ${TAGLIB_LIBRARIES})
 add_test(test_filehash test_filehash)
 
 
@@ -105,12 +99,10 @@ add_test(test_networkutil test_networkutil)
 qt5_wrap_cpp(PMP_TestNetworkProtocol_MOCS test_networkprotocol.h)
 add_executable(test_networkprotocol test_networkprotocol.cpp
     ${PMP_TestNetworkProtocol_MOCS}
-    ${CMAKE_SOURCE_DIR}/src/common/networkprotocol.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/networkutil.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/filehash.cpp
-    ${CMAKE_SOURCE_DIR}/src/common/util.cpp
 )
+target_link_libraries(test_networkprotocol $<TARGET_OBJECTS:PmpCommon>)
 target_link_libraries(test_networkprotocol Qt5::Core Qt5::Test)
+target_link_libraries(test_networkprotocol ${TAGLIB_LIBRARIES})
 add_test(test_networkprotocol test_networkprotocol)
 
 


### PR DESCRIPTION
Use CMake object libraries in order to avoid compiling the same files multiple times.