### PR TITLE
Add four new commands to the command-line remote

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -102,7 +102,6 @@ IDEAS
  * add button to copy title and artist of current track to clipboard
  * server database backup and restore
  * detect track BPM automatically
- * command-line remote: add a command for switching between public mode and personal mode
  * command-line remote: add a command for turning dynamic mode on/off
  * command-line remote: add a command for manually inserting a track into the queue
  * command-line remote: add a command for seeking (going to a specific time in the current track)

--- a/TODOs.txt
+++ b/TODOs.txt
@@ -106,6 +106,7 @@ IDEAS
  * command-line remote: add a command for turning dynamic mode on/off
  * command-line remote: add a command for manually inserting a track into the queue
  * command-line remote: add a command for seeking (going to a specific time in the current track)
+ * command-line remote: extend the "nowplaying" command to also print album
  * command-line remote: extend the "trackstats" command to accept queue IDs
  * command-line remote: extend the "qmove" command to accept "front" or "end" as destination
  * hash tool: by default only output the hash of the file, no other information

--- a/TODOs.txt
+++ b/TODOs.txt
@@ -104,6 +104,7 @@ IDEAS
  * detect track BPM automatically
  * command-line remote: add a command for manually inserting a track into the queue
  * command-line remote: add a command for seeking (going to a specific time in the current track)
+ * command-line remote: add a command for printing recent player history
  * command-line remote: extend the "nowplaying" command to also print album
  * command-line remote: extend the "trackstats" command to accept queue IDs
  * command-line remote: extend the "qmove" command to accept "front" or "end" as destination

--- a/TODOs.txt
+++ b/TODOs.txt
@@ -102,7 +102,6 @@ IDEAS
  * add button to copy title and artist of current track to clipboard
  * server database backup and restore
  * detect track BPM automatically
- * command-line remote: add a command for turning dynamic mode on/off
  * command-line remote: add a command for manually inserting a track into the queue
  * command-line remote: add a command for seeking (going to a specific time in the current track)
  * command-line remote: extend the "nowplaying" command to also print album

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,22 +240,16 @@ if (NOT ENABLE_WIN32_CONSOLE)
   set(PMP_WIN32_FLAG WIN32)
 endif (NOT ENABLE_WIN32_CONSOLE)
 
-add_library(PmpCommon OBJECT
-    ${PMP_COMMON_SOURCES}
-    ${PMP_COMMON_MOCS}
-)
+add_library(PmpCommon OBJECT ${PMP_COMMON_SOURCES} ${PMP_COMMON_MOCS})
 target_link_libraries(PmpCommon Qt5::Core)
 
-add_library(PmpClient OBJECT
-    ${PMP_CLIENT_SOURCES}
-    ${PMP_CLIENT_MOCS}
-)
+add_library(PmpClient OBJECT ${PMP_CLIENT_SOURCES} ${PMP_CLIENT_MOCS})
 target_link_libraries(PmpClient Qt5::Core Qt5::Network)
 
-add_library(PmpServer OBJECT
-    ${PMP_SERVER_SOURCES}
-    ${PMP_SERVER_MOCS}
-)
+add_library(PmpCmdRemote OBJECT ${PMP_CMD_REMOTE_SOURCES} ${PMP_CMD_REMOTE_MOCS})
+target_link_libraries(PmpCmdRemote Qt5::Core Qt5::Network)
+
+add_library(PmpServer OBJECT ${PMP_SERVER_SOURCES} ${PMP_SERVER_MOCS})
 target_link_libraries(PmpServer Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
 
 add_executable(PMP-HashTool

--- a/src/client/dynamicmodecontroller.h
+++ b/src/client/dynamicmodecontroller.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -42,6 +42,7 @@ namespace PMP::Client
         virtual int waveProgressTotal() const = 0;
 
     public Q_SLOTS:
+        virtual void setDynamicModeEnabled(bool enabled) = 0;
         virtual void enableDynamicMode() = 0;
         virtual void disableDynamicMode() = 0;
 

--- a/src/client/dynamicmodecontrollerimpl.cpp
+++ b/src/client/dynamicmodecontrollerimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -86,6 +86,14 @@ namespace PMP::Client
     int DynamicModeControllerImpl::waveProgressTotal() const
     {
         return _waveProgressTotal;
+    }
+
+    void DynamicModeControllerImpl::setDynamicModeEnabled(bool enabled)
+    {
+        if (enabled)
+            enableDynamicMode();
+        else
+            disableDynamicMode();
     }
 
     void DynamicModeControllerImpl::enableDynamicMode()

--- a/src/client/dynamicmodecontrollerimpl.h
+++ b/src/client/dynamicmodecontrollerimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -42,6 +42,7 @@ namespace PMP::Client
         int waveProgressTotal() const override;
 
     public Q_SLOTS:
+        void setDynamicModeEnabled(bool enabled) override;
         void enableDynamicMode() override;
         void disableDynamicMode() override;
 

--- a/src/cmd-remote/cmd-remote-main.cpp
+++ b/src/cmd-remote/cmd-remote-main.cpp
@@ -40,6 +40,7 @@ usage:
 
   commands:
     login: force authentication before running the next command (see below)
+    status: get status information, like volume, queue length... (see below)
     play: start/resume playback
     pause: pause playback
     skip: jump to next track in the queue
@@ -74,6 +75,12 @@ usage:
     When reading username and password from standard input, it is assumed
     that the first line of the input is the username and the second line is
     the password.
+
+  'status' command:
+    This command does not require arguments and can be used without
+    authenticating first. It provides general information about the server,
+    like: is a track loaded, is something playing, what is the volume, what
+    is the length of the queue, is dynamic mode active, etc.
 
   'insert' command:
     insert break front: insert a break at the front of the queue
@@ -151,6 +158,7 @@ usage:
     client.
 
   Examples:
+    {{PROGRAMNAME}} localhost status
     {{PROGRAMNAME}} localhost nowplaying
     {{PROGRAMNAME}} localhost personalmode
     {{PROGRAMNAME}} localhost dynamicmode on

--- a/src/cmd-remote/cmd-remote-main.cpp
+++ b/src/cmd-remote/cmd-remote-main.cpp
@@ -49,6 +49,7 @@ usage:
     queue: print queue length and the first tracks waiting in the queue
     personalmode: switch to personal mode
     publicmode: switch to public mode
+    dynamicmode on|off: enable/disable dynamic mode (auto queue fill)
     break: insert a break at the front of the queue if not present there yet
     insert <item-type> <position>: insert an item into the queue (see below)
     qdel <QID>: delete an entry from the queue
@@ -152,6 +153,7 @@ usage:
   Examples:
     {{PROGRAMNAME}} localhost nowplaying
     {{PROGRAMNAME}} localhost personalmode
+    {{PROGRAMNAME}} localhost dynamicmode on
     {{PROGRAMNAME}} localhost queue
     {{PROGRAMNAME}} ::1 volume
     {{PROGRAMNAME}} localhost volume 100

--- a/src/cmd-remote/cmd-remote-main.cpp
+++ b/src/cmd-remote/cmd-remote-main.cpp
@@ -47,6 +47,8 @@ usage:
     volume <number>: set volume percentage (0-100)
     nowplaying: get info about the track currently playing
     queue: print queue length and the first tracks waiting in the queue
+    personalmode: switch to personal mode
+    publicmode: switch to public mode
     break: insert a break at the front of the queue if not present there yet
     insert <item-type> <position>: insert an item into the queue (see below)
     qdel <QID>: delete an entry from the queue
@@ -148,6 +150,8 @@ usage:
     client.
 
   Examples:
+    {{PROGRAMNAME}} localhost nowplaying
+    {{PROGRAMNAME}} localhost personalmode
     {{PROGRAMNAME}} localhost queue
     {{PROGRAMNAME}} ::1 volume
     {{PROGRAMNAME}} localhost volume 100
@@ -155,7 +159,6 @@ usage:
     {{PROGRAMNAME}} localhost insert break index 2
     {{PROGRAMNAME}} localhost insert barrier front
     {{PROGRAMNAME}} localhost qmove 42 +3
-    {{PROGRAMNAME}} localhost nowplaying
     {{PROGRAMNAME}} localhost login : nowplaying
     {{PROGRAMNAME}} localhost login MyUsername : play
     {{PROGRAMNAME}} localhost login MyUsername - : play <passwordfile

--- a/src/cmd-remote/commandbase.h
+++ b/src/cmd-remote/commandbase.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,6 +21,7 @@
 #define PMP_COMMANDBASE_H
 
 #include "common/future.h"
+#include "common/nullable.h"
 #include "common/resultmessageerrorcode.h"
 
 #include "command.h"
@@ -40,10 +41,12 @@ namespace PMP
         virtual void execute(Client::ServerInterface* serverInterface) final;
 
     protected:
+        class StepResult;
+        enum class StepResultType { StepIncomplete, StepCompleted, CommandFinished };
+
         CommandBase();
 
-        // TODO : make return type of each step an enum instead of bool
-        void addStep(std::function<bool ()> step);
+        void addStep(std::function<StepResult ()> step);
         void setStepDelay(int milliseconds);
         void setCommandExecutionSuccessful(QString output = "");
         void setCommandExecutionFailed(int resultCode, QString errorOutput);
@@ -57,10 +60,77 @@ namespace PMP
         void listenerSlot();
 
     private:
+        void reportInternalError();
+        void applyFinishedCommandFromStepResult(StepResult const& stepResult);
+
         int _currentStep;
         int _stepDelayMilliseconds;
-        QVector<std::function<bool ()>> _steps;
+        QVector<std::function<StepResult ()>> _steps;
         bool _finishedOrFailed;
+    };
+
+    class CommandBase::StepResult
+    {
+    public:
+        static StepResult stepCompleted()
+        {
+            return StepResult(StepResultType::StepCompleted);
+        }
+
+        static StepResult stepIncomplete()
+        {
+            return StepResult(StepResultType::StepIncomplete);
+        }
+
+        static StepResult commandCompleted()
+        {
+            return StepResult(StepResultType::CommandFinished);
+        }
+
+        static StepResult commandSuccessful()
+        {
+            return StepResult(0);
+        }
+
+        static StepResult commandSuccessful(QString output)
+        {
+            return StepResult(0, output);
+        }
+
+        static StepResult commandFailed(int errorCode, QString errorMessage)
+        {
+            return StepResult(errorCode, errorMessage);
+        }
+
+        StepResultType type() const { return _type; }
+        Nullable<int> commandErrorCode() const { return _commandErrorCode; }
+        QString commandOutput() const { return _commandOutput; }
+
+    private:
+        StepResult(StepResultType type)
+         : _type(type)
+        {
+            //
+        }
+
+        StepResult(int commandErrorCode)
+         : _type(StepResultType::CommandFinished),
+           _commandErrorCode(commandErrorCode)
+        {
+            //
+        }
+
+        StepResult(int commandErrorCode, QString output)
+         : _type(StepResultType::CommandFinished),
+           _commandErrorCode(commandErrorCode),
+           _commandOutput(output)
+        {
+            //
+        }
+
+        StepResultType _type;
+        Nullable<int> _commandErrorCode;
+        QString _commandOutput;
     };
 }
 #endif

--- a/src/cmd-remote/commandparser.cpp
+++ b/src/cmd-remote/commandparser.cpp
@@ -325,6 +325,10 @@ namespace PMP
         {
             handleCommandNotRequiringArguments<PublicModeCommand>(commandWithArgs);
         }
+        else if (command == "dynamicmode")
+        {
+            parseDynamicModeCommand(args);
+        }
         else if (command == "reloadserversettings")
         {
             handleCommandNotRequiringArguments<ReloadServerSettingsCommand>(
@@ -693,6 +697,37 @@ namespace PMP
         }
 
         _command = new TrackStatsCommand(hash);
+    }
+
+    void CommandParser::parseDynamicModeCommand(CommandArguments arguments)
+    {
+        if (arguments.noCurrent())
+        {
+            _errorMessage = "Command 'dynamicmode' requires at least one argument!";
+            return;
+        }
+
+        if (arguments.currentIsOneOf({"on", "off"}))
+        {
+            bool isOn = arguments.current() == "on";
+            arguments.advance();
+            parseDynamicModeOnOrOff(arguments, isOn);
+        }
+        else
+        {
+            _errorMessage = "Expected 'on' or 'off' after 'dynamicmode'!";
+        }
+    }
+
+    void CommandParser::parseDynamicModeOnOrOff(CommandArguments& arguments, bool isOn)
+    {
+        if (arguments.haveCurrent())
+        {
+            _errorMessage = "Command has too many arguments!";
+            return;
+        }
+
+        _command = new DynamicModeActivationCommand(isOn);
     }
 
     bool CommandParser::isInFuture(QDateTime time)

--- a/src/cmd-remote/commandparser.cpp
+++ b/src/cmd-remote/commandparser.cpp
@@ -317,6 +317,14 @@ namespace PMP
         {
             handleCommandNotRequiringArguments<QueueCommand>(commandWithArgs);
         }
+        else if (command == "personalmode")
+        {
+            handleCommandNotRequiringArguments<PersonalModeCommand>(commandWithArgs);
+        }
+        else if (command == "publicmode")
+        {
+            handleCommandNotRequiringArguments<PublicModeCommand>(commandWithArgs);
+        }
         else if (command == "reloadserversettings")
         {
             handleCommandNotRequiringArguments<ReloadServerSettingsCommand>(

--- a/src/cmd-remote/commandparser.cpp
+++ b/src/cmd-remote/commandparser.cpp
@@ -293,7 +293,11 @@ namespace PMP
         auto args = commandWithArgs.mid(1);
         auto argsCount = args.size();
 
-        if (command == "play")
+        if (command == "status")
+        {
+            handleCommandNotRequiringArguments<StatusCommand>(commandWithArgs);
+        }
+        else if (command == "play")
         {
             handleCommandNotRequiringArguments<PlayCommand>(commandWithArgs);
         }

--- a/src/cmd-remote/commandparser.h
+++ b/src/cmd-remote/commandparser.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -117,6 +117,8 @@ namespace PMP
         void parseDelayedStartAt(CommandArguments& arguments);
         void parseDelayedStartWait(CommandArguments& arguments);
         void parseTrackStatsCommand(CommandArguments arguments);
+        void parseDynamicModeCommand(CommandArguments arguments);
+        void parseDynamicModeOnOrOff(CommandArguments& arguments, bool isOn);
 
         template <class SomeCommand>
         void handleCommandNotRequiringArguments(QVector<QString> commandWithArgs);

--- a/src/cmd-remote/commands.cpp
+++ b/src/cmd-remote/commands.cpp
@@ -376,11 +376,6 @@ namespace PMP
 
     /* ===== PlayCommand ===== */
 
-    PlayCommand::PlayCommand()
-    {
-        //
-    }
-
     bool PlayCommand::requiresAuthentication() const
     {
         return true;
@@ -408,11 +403,6 @@ namespace PMP
 
     /* ===== PauseCommand ===== */
 
-    PauseCommand::PauseCommand()
-    {
-        //
-    }
-
     bool PauseCommand::requiresAuthentication() const
     {
         return true;
@@ -439,12 +429,6 @@ namespace PMP
     }
 
     /* ===== SkipCommand ===== */
-
-    SkipCommand::SkipCommand()
-     : _currentQueueId(0)
-    {
-        //
-    }
 
     bool SkipCommand::requiresAuthentication() const
     {
@@ -488,11 +472,6 @@ namespace PMP
     }
 
     /* ===== NowPlayingCommand ===== */
-
-    NowPlayingCommand::NowPlayingCommand()
-    {
-        //
-    }
 
     bool NowPlayingCommand::requiresAuthentication() const
     {
@@ -562,12 +541,6 @@ namespace PMP
     }
 
     /* ===== QueueCommand ===== */
-
-    QueueCommand::QueueCommand()
-     : _fetchLimit(10)
-    {
-        //
-    }
 
     bool QueueCommand::requiresAuthentication() const
     {
@@ -763,11 +736,6 @@ namespace PMP
 
     /* ===== GetVolumeCommand ===== */
 
-    GetVolumeCommand::GetVolumeCommand()
-    {
-        //
-    }
-
     bool GetVolumeCommand::requiresAuthentication() const
     {
         return false;
@@ -830,11 +798,6 @@ namespace PMP
     }
 
     /* ===== BreakCommand =====*/
-
-    BreakCommand::BreakCommand()
-    {
-        //
-    }
 
     bool BreakCommand::requiresAuthentication() const
     {

--- a/src/cmd-remote/commands.cpp
+++ b/src/cmd-remote/commands.cpp
@@ -525,6 +525,7 @@ namespace PMP
 
                 auto title = currentTrackMonitor->currentTrackTitle();
                 auto artist = currentTrackMonitor->currentTrackArtist();
+                //auto album = currentTrackMonitor->currentTrackAlbum(); NOT AVAILABLE YET
                 auto possibleFileName =
                         currentTrackMonitor->currentTrackPossibleFilename();
 
@@ -547,6 +548,7 @@ namespace PMP
                 output += " QID: " + QString::number(queueId) + "\n";
                 output += " title: " + title + "\n";
                 output += " artist: " + artist + "\n";
+                //output += " album: " + album + "\n";
                 output += " length: " + lengthString + "\n";
 
                 if (title.isEmpty() && artist.isEmpty())

--- a/src/cmd-remote/commands.h
+++ b/src/cmd-remote/commands.h
@@ -90,6 +90,21 @@ namespace PMP
         void run(Client::ServerInterface* serverInterface) override;
     };
 
+    class DynamicModeActivationCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        explicit DynamicModeActivationCommand(bool enable);
+
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
+
+    private:
+        bool _enable;
+    };
+
     class DelayedStartAtCommand : public CommandBase
     {
         Q_OBJECT

--- a/src/cmd-remote/commands.h
+++ b/src/cmd-remote/commands.h
@@ -178,8 +178,8 @@ namespace PMP
         void run(Client::ServerInterface* serverInterface) override;
 
     private:
-        void printQueue(Client::AbstractQueueMonitor* queueMonitor,
-                        Client::QueueEntryInfoStorage* queueEntryInfoStorage);
+        StepResult printQueue(Client::AbstractQueueMonitor* queueMonitor,
+                              Client::QueueEntryInfoStorage* queueEntryInfoStorage);
         QString getSpecialEntryText(Client::QueueEntryInfo const* entry) const;
 
         int _fetchLimit;

--- a/src/cmd-remote/commands.h
+++ b/src/cmd-remote/commands.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -68,6 +68,26 @@ namespace PMP
 
     private:
         RequestID _requestId;
+    };
+
+    class PersonalModeCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
+    };
+
+    class PublicModeCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
     };
 
     class DelayedStartAtCommand : public CommandBase

--- a/src/cmd-remote/commands.h
+++ b/src/cmd-remote/commands.h
@@ -41,8 +41,6 @@ namespace PMP::Client
 
 namespace PMP
 {
-    // TODO : remove useless constructors
-
     struct VersionInfo;
 
     class StatusCommand : public CommandBase
@@ -172,8 +170,6 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        PlayCommand();
-
         bool requiresAuthentication() const override;
 
     protected:
@@ -184,8 +180,6 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        PauseCommand();
-
         bool requiresAuthentication() const override;
 
     protected:
@@ -196,23 +190,19 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        SkipCommand();
-
         bool requiresAuthentication() const override;
 
     protected:
         void run(Client::ServerInterface* serverInterface) override;
 
     private:
-        quint32 _currentQueueId;
+        quint32 _currentQueueId { 0 };
     };
 
     class NowPlayingCommand : public CommandBase
     {
         Q_OBJECT
     public:
-        NowPlayingCommand();
-
         bool requiresAuthentication() const override;
 
     protected:
@@ -223,8 +213,6 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        QueueCommand();
-
         bool requiresAuthentication() const override;
 
     protected:
@@ -235,7 +223,7 @@ namespace PMP
                               Client::QueueEntryInfoStorage* queueEntryInfoStorage);
         QString getSpecialEntryText(Client::QueueEntryInfo const* entry) const;
 
-        int _fetchLimit;
+        int _fetchLimit { 10 };
     };
 
     class ShutdownCommand : public CommandBase
@@ -258,8 +246,6 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        GetVolumeCommand();
-
         bool requiresAuthentication() const override;
 
     protected:
@@ -285,8 +271,6 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        BreakCommand();
-
         bool requiresAuthentication() const override;
 
     protected:

--- a/src/cmd-remote/commands.h
+++ b/src/cmd-remote/commands.h
@@ -32,6 +32,9 @@
 namespace PMP::Client
 {
     class AbstractQueueMonitor;
+    class CurrentTrackMonitor;
+    class DynamicModeController;
+    class PlayerController;
     class QueueEntryInfo;
     class QueueEntryInfoStorage;
 }
@@ -41,6 +44,21 @@ namespace PMP
     // TODO : remove useless constructors
 
     struct VersionInfo;
+
+    class StatusCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
+
+    private:
+        StepResult printStatus(Client::PlayerController* playerController,
+                               Client::CurrentTrackMonitor* currentTrackMonitor,
+                               Client::DynamicModeController* dynamicModeController);
+    };
 
     class ServerVersionCommand : public CommandBase
     {

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -59,6 +59,19 @@ add_hashtest(
 )
 
 
+# TestCommandParser
+qt5_wrap_cpp(PMP_TestCommandParser_MOCS
+    test_commandparser.h
+)
+add_executable(test_commandparser test_commandparser.cpp ${PMP_TestCommandParser_MOCS})
+target_link_libraries(test_commandparser $<TARGET_OBJECTS:PmpCmdRemote>)
+target_link_libraries(test_commandparser $<TARGET_OBJECTS:PmpClient>)
+target_link_libraries(test_commandparser $<TARGET_OBJECTS:PmpCommon>)
+target_link_libraries(test_commandparser Qt5::Core Qt5::Network Qt5::Test)
+target_link_libraries(test_commandparser ${TAGLIB_LIBRARIES})
+add_test(test_commandparser test_commandparser)
+
+
 # TestNullable
 qt5_wrap_cpp(PMP_TestNullable_MOCS test_nullable.h)
 add_executable(test_nullable test_nullable.cpp ${PMP_TestNullable_MOCS})

--- a/testing/test_commandparser.cpp
+++ b/testing/test_commandparser.cpp
@@ -1,0 +1,133 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "test_commandparser.h"
+
+#include "cmd-remote/command.h"
+#include "cmd-remote/commands.h"
+#include "cmd-remote/commandparser.h"
+
+#include <QtTest/QTest>
+
+using namespace PMP;
+
+template<class CommandType>
+void verifySuccessfulParsingOf(QVector<QString> commandWithArgs)
+{
+    CommandParser parser;
+    parser.parse(commandWithArgs);
+
+    QVERIFY(parser.parsedSuccessfully());
+    QCOMPARE(parser.errorMessage(), "");
+
+    auto* commandObject = dynamic_cast<CommandType*>(parser.command());
+    QVERIFY(commandObject != nullptr);
+}
+
+void verifyParseError(QVector<QString> commandWithArgs)
+{
+    CommandParser parser;
+    parser.parse(commandWithArgs);
+
+    QVERIFY(!parser.parsedSuccessfully());
+    QVERIFY(parser.errorMessage().length() > 0);
+    QVERIFY(parser.command() == nullptr);
+}
+
+void TestCommandParser::playCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<PlayCommand>({"play"});
+}
+
+void TestCommandParser::playCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"play", "xyz"});
+}
+
+void TestCommandParser::pauseCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<PauseCommand>({"pause"});
+}
+
+void TestCommandParser::pauseCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"pause", "xyz"});
+}
+
+void TestCommandParser::skipCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<SkipCommand>({"skip"});
+}
+
+void TestCommandParser::skipCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"skip", "xyz"});
+}
+
+void TestCommandParser::breakCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<BreakCommand>({"break"});
+}
+
+void TestCommandParser::breakCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"break", "xyz"});
+}
+
+void TestCommandParser::nowplayingCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<NowPlayingCommand>({"nowplaying"});
+}
+
+void TestCommandParser::nowplayingCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"nowplaying", "xyz"});
+}
+
+void TestCommandParser::queueCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<QueueCommand>({"queue"});
+}
+
+void TestCommandParser::queueCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"queue", "xyz"});
+}
+
+void TestCommandParser::reloadserversettingsCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<ReloadServerSettingsCommand>({"reloadserversettings"});
+}
+
+void TestCommandParser::reloadserversettingsCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"reloadserversettings", "xyz"});
+}
+
+void TestCommandParser::shutdownCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<ShutdownCommand>({"shutdown"});
+}
+
+void TestCommandParser::shutdownCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"shutdown", "xyz"});
+}
+
+QTEST_MAIN(TestCommandParser)

--- a/testing/test_commandparser.cpp
+++ b/testing/test_commandparser.cpp
@@ -130,6 +130,21 @@ void TestCommandParser::publicmodeCommandDoesNotAcceptArguments()
     verifyParseError({"publicmode", "xyz"});
 }
 
+void TestCommandParser::dynamicmodeCommandTestValid()
+{
+    verifySuccessfulParsingOf<DynamicModeActivationCommand>({"dynamicmode", "on"});
+    verifySuccessfulParsingOf<DynamicModeActivationCommand>({"dynamicmode", "off"});
+}
+
+void TestCommandParser::dynamicmodeCommandTestInvalid()
+{
+    verifyParseError({"dynamicmode"});
+
+    verifyParseError({"dynamicmode", "abcd"});
+    verifyParseError({"dynamicmode", "on", "on"});
+    verifyParseError({"dynamicmode", "off", "off"});
+}
+
 void TestCommandParser::reloadserversettingsCommandCanBeParsed()
 {
     verifySuccessfulParsingOf<ReloadServerSettingsCommand>({"reloadserversettings"});

--- a/testing/test_commandparser.cpp
+++ b/testing/test_commandparser.cpp
@@ -110,6 +110,26 @@ void TestCommandParser::queueCommandDoesNotAcceptArguments()
     verifyParseError({"queue", "xyz"});
 }
 
+void TestCommandParser::personalmodeCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<PersonalModeCommand>({"personalmode"});
+}
+
+void TestCommandParser::personalmodeCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"personalmode", "xyz"});
+}
+
+void TestCommandParser::publicmodeCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<PublicModeCommand>({"publicmode"});
+}
+
+void TestCommandParser::publicmodeCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"publicmode", "xyz"});
+}
+
 void TestCommandParser::reloadserversettingsCommandCanBeParsed()
 {
     verifySuccessfulParsingOf<ReloadServerSettingsCommand>({"reloadserversettings"});

--- a/testing/test_commandparser.cpp
+++ b/testing/test_commandparser.cpp
@@ -50,6 +50,16 @@ void verifyParseError(QVector<QString> commandWithArgs)
     QVERIFY(parser.command() == nullptr);
 }
 
+void TestCommandParser::statusCommandCanBeParsed()
+{
+    verifySuccessfulParsingOf<StatusCommand>({"status"});
+}
+
+void TestCommandParser::statusCommandDoesNotAcceptArguments()
+{
+    verifyParseError({"status", "xyz"});
+}
+
 void TestCommandParser::playCommandCanBeParsed()
 {
     verifySuccessfulParsingOf<PlayCommand>({"play"});

--- a/testing/test_commandparser.h
+++ b/testing/test_commandparser.h
@@ -55,6 +55,9 @@ private Q_SLOTS:
     void publicmodeCommandCanBeParsed();
     void publicmodeCommandDoesNotAcceptArguments();
 
+    void dynamicmodeCommandTestValid();
+    void dynamicmodeCommandTestInvalid();
+
     void reloadserversettingsCommandCanBeParsed();
     void reloadserversettingsCommandDoesNotAcceptArguments();
 

--- a/testing/test_commandparser.h
+++ b/testing/test_commandparser.h
@@ -49,6 +49,12 @@ private Q_SLOTS:
     void queueCommandCanBeParsed();
     void queueCommandDoesNotAcceptArguments();
 
+    void personalmodeCommandCanBeParsed();
+    void personalmodeCommandDoesNotAcceptArguments();
+
+    void publicmodeCommandCanBeParsed();
+    void publicmodeCommandDoesNotAcceptArguments();
+
     void reloadserversettingsCommandCanBeParsed();
     void reloadserversettingsCommandDoesNotAcceptArguments();
 

--- a/testing/test_commandparser.h
+++ b/testing/test_commandparser.h
@@ -31,6 +31,9 @@ class TestCommandParser : public QObject
 {
     Q_OBJECT
 private Q_SLOTS:
+    void statusCommandCanBeParsed();
+    void statusCommandDoesNotAcceptArguments();
+
     void playCommandCanBeParsed();
     void playCommandDoesNotAcceptArguments();
 

--- a/testing/test_commandparser.h
+++ b/testing/test_commandparser.h
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_TESTCOMMANDPARSER_H
+#define PMP_TESTCOMMANDPARSER_H
+
+#include <QObject>
+
+namespace PMP
+{
+    class CommandParser;
+}
+
+class TestCommandParser : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void playCommandCanBeParsed();
+    void playCommandDoesNotAcceptArguments();
+
+    void pauseCommandCanBeParsed();
+    void pauseCommandDoesNotAcceptArguments();
+
+    void skipCommandCanBeParsed();
+    void skipCommandDoesNotAcceptArguments();
+
+    void breakCommandCanBeParsed();
+    void breakCommandDoesNotAcceptArguments();
+
+    void nowplayingCommandCanBeParsed();
+    void nowplayingCommandDoesNotAcceptArguments();
+
+    void queueCommandCanBeParsed();
+    void queueCommandDoesNotAcceptArguments();
+
+    void reloadserversettingsCommandCanBeParsed();
+    void reloadserversettingsCommandDoesNotAcceptArguments();
+
+    void shutdownCommandCanBeParsed();
+    void shutdownCommandDoesNotAcceptArguments();
+};
+#endif


### PR DESCRIPTION
Add the following commands to the command-line remote:

* `personalmode` for switching to personal mode
* `publicmode` for switching to public mode
* `dynamicmode` for turning dynamic mode on/off
* `status` for getting general status information
