### PR TITLE
CMD Remote: add command for inserting a track

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -103,7 +103,6 @@ IDEAS
  * add button to copy title and artist of current track to clipboard
  * server database backup and restore
  * detect track BPM automatically
- * command-line remote: add a command for manually inserting a track into the queue
  * command-line remote: add a command for seeking (going to a specific time in the current track)
  * command-line remote: add a command for printing recent player history
  * command-line remote: extend the "nowplaying" command to also print album

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -278,9 +278,9 @@ target_link_libraries(PMP-Server
 
 add_executable(PMP-Cmd-Remote
     cmd-remote/cmd-remote-main.cpp
-    ${PMP_CMD_REMOTE_SOURCES} ${PMP_CMD_REMOTE_MOCS}
 )
 target_link_libraries(PMP-Cmd-Remote
+    $<TARGET_OBJECTS:PmpCmdRemote>
     $<TARGET_OBJECTS:PmpClient>
     $<TARGET_OBJECTS:PmpCommon>
 )

--- a/src/client/abstractqueuemonitor.h
+++ b/src/client/abstractqueuemonitor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -36,12 +36,14 @@ namespace PMP::Client
 
         virtual QUuid serverUuid() const = 0;
 
+        virtual bool isQueueLengthKnown() const = 0;
         virtual int queueLength() const = 0;
         virtual quint32 queueEntry(int index) = 0;
         virtual QList<quint32> knownQueuePart() const = 0;
         virtual bool isFetchCompleted() const = 0;
 
     Q_SIGNALS:
+        void queueLengthChanged();
         void fetchCompleted();
         void queueResetted(int queueLength);
         void entriesReceived(int index, QList<quint32> entries);

--- a/src/client/queuemonitor.h
+++ b/src/client/queuemonitor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -36,6 +36,7 @@ namespace PMP::Client
 
         QUuid serverUuid() const override { return _serverUuid; }
 
+        bool isQueueLengthKnown() const override { return _queueLengthIsKnown; }
         int queueLength() const override { return _queueLength; }
         quint32 queueEntry(int index) override;
         QList<quint32> knownQueuePart() const override { return _queue; }
@@ -58,7 +59,7 @@ namespace PMP::Client
 
     private:
         void gotRequestForEntryAtIndex(int index);
-        void updateQueueLength(int queueLength, bool forceReload);
+        bool updateQueueLength(int queueLength, bool forceReload);
         void sendInitialQueueFetchRequest();
         bool verifyQueueContentsOldAndNew(int startIndex,
                                           const QList<quint32>& newContent);
@@ -73,6 +74,7 @@ namespace PMP::Client
         int _queueFetchLimit;
         int _queueRequestedEntryCount;
         QList<quint32> _queue; // no need for a QQueue, a QList will suffice
+        bool _queueLengthIsKnown;
         bool _fetchCompletedEmitted;
     };
 }

--- a/src/cmd-remote/cmd-remote-main.cpp
+++ b/src/cmd-remote/cmd-remote-main.cpp
@@ -52,7 +52,7 @@ usage:
     publicmode: switch to public mode
     dynamicmode on|off: enable/disable dynamic mode (auto queue fill)
     break: insert a break at the front of the queue if not present there yet
-    insert <item-type> <position>: insert an item into the queue (see below)
+    insert <item> <position>: insert an item into the queue (see below)
     qdel <QID>: delete an entry from the queue
     qmove <QID> <-diff>: move a track up in the queue (e.g. -3)
     qmove <QID> <+diff>: move a track down in the queue (eg. +2)
@@ -83,13 +83,19 @@ usage:
     is the length of the queue, is dynamic mode active, etc.
 
   'insert' command:
-    insert break front: insert a break at the front of the queue
-    insert break end: insert a break at the end of the queue
-    insert break index <number>: insert a break at the specified index
-    insert barrier end: insert a barrier at the end of the queue
+    insert break <position>: insert a break into the queue
+    insert barrier <position>: insert a barrier into the queue
+    insert <hash> <position>: insert a track into the queue
+    insert <item> front: insert something at the front of the queue
+    insert <item> end: insert something at the end of the queue
+    insert <item> index <number>: insert something at a specific index
 
-    The numeric index is zero-based, meaning that 0 indicates the front of
-    the queue.
+    This command inserts a single item into the queue at a specific
+    position. The item to be inserted can be a track, a break, or a
+    barrier. The position can be the front of the queue, the end of the
+    queue, or a specific index counted from the front. The index is
+    zero-based, meaning that index 0 refers to the front of the queue,
+    index 1 indicates after the first existing item, etc.
     Inserting a break or a barrier with the 'insert' command requires a
     fairly recent version of the PMP server in order to work. Older servers
     do not support barriers, and they only support inserting a break at the
@@ -97,7 +103,10 @@ usage:
     yet at that location (see the 'break' command).
     A barrier is like a break, but is never consumed. Playback just stops
     when the current track finishes and the first item in the queue is a
-    barrier.
+    barrier. The barrier will remain in the queue until it is deleted by
+    the user.
+    The hash of a track can be obtained with the 'track info' dialog in the
+    GUI Remote or with the command-line hash tool.
 
   'delayedstart' command:
     delayedstart abort: cancel delayed start
@@ -131,8 +140,8 @@ usage:
 
     Retrieves 'last heard' and 'score' for the current user and the track
     that was specified as an argument.
-    The track hash can be obtained with the 'track info' dialog in the
-    GUI Remote or the command-line hash tool.
+    The hash of a track can be obtained with the 'track info' dialog in the
+    GUI Remote or with the command-line hash tool.
 
   NOTICE:
     Some commands require a fairly recent version of the PMP server in order

--- a/src/cmd-remote/commandbase.h
+++ b/src/cmd-remote/commandbase.h
@@ -67,6 +67,7 @@ namespace PMP
         int _stepDelayMilliseconds;
         QVector<std::function<StepResult ()>> _steps;
         bool _finishedOrFailed;
+        bool _stepsCompleted;
     };
 
     class CommandBase::StepResult
@@ -102,8 +103,14 @@ namespace PMP
             return StepResult(errorCode, errorMessage);
         }
 
+        static StepResult commandFailed(ResultMessageErrorCode error)
+        {
+            return StepResult(error);
+        }
+
         StepResultType type() const { return _type; }
-        Nullable<int> commandErrorCode() const { return _commandErrorCode; }
+        Nullable<ResultMessageErrorCode> commandResult() const { return _commandResult; }
+        Nullable<int> commandExitCode() const { return _commandExitCode; }
         QString commandOutput() const { return _commandOutput; }
 
     private:
@@ -113,23 +120,31 @@ namespace PMP
             //
         }
 
-        StepResult(int commandErrorCode)
+        StepResult(int commandExitCode)
          : _type(StepResultType::CommandFinished),
-           _commandErrorCode(commandErrorCode)
+           _commandExitCode(commandExitCode)
         {
             //
         }
 
-        StepResult(int commandErrorCode, QString output)
+        StepResult(int commandExitCode, QString output)
          : _type(StepResultType::CommandFinished),
-           _commandErrorCode(commandErrorCode),
+           _commandExitCode(commandExitCode),
            _commandOutput(output)
         {
             //
         }
 
+        StepResult(ResultMessageErrorCode error)
+         : _type(StepResultType::CommandFinished),
+           _commandResult(error)
+        {
+            //
+        }
+
         StepResultType _type;
-        Nullable<int> _commandErrorCode;
+        Nullable<ResultMessageErrorCode> _commandResult;
+        Nullable<int> _commandExitCode;
         QString _commandOutput;
     };
 }

--- a/src/cmd-remote/commandparser.h
+++ b/src/cmd-remote/commandparser.h
@@ -112,7 +112,7 @@ namespace PMP
         void splitMultipleCommandsInOne(QVector<QString>& commandWithArgs);
         void parseExplicitLoginAndSeparator(QVector<QString>& commandWithArgs);
         void parseCommand(QVector<QString> commandWithArgs);
-        void parseInsertCommand(QVector<QString> arguments);
+        void parseInsertCommand(CommandArguments arguments);
         void parseDelayedStartCommand(CommandArguments arguments);
         void parseDelayedStartAt(CommandArguments& arguments);
         void parseDelayedStartWait(CommandArguments& arguments);

--- a/src/cmd-remote/commands.h
+++ b/src/cmd-remote/commands.h
@@ -296,6 +296,45 @@ namespace PMP
         RequestID _requestId;
     };
 
+    class QueueInsertTrackCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        QueueInsertTrackCommand(FileHash const& hash, int index,
+                                QueueIndexType indexType);
+
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
+
+    private:
+        void insertNormal(Client::ServerInterface* serverInterface);
+        void insertReversed(Client::ServerInterface* serverInterface);
+
+        FileHash _hash;
+        int _index;
+        QueueIndexType _indexType;
+        RequestID _requestId;
+    };
+
+    class InsertCommandBuilder
+    {
+    public:
+        void setItem(SpecialQueueItemType specialItemType);
+        void setItem(FileHash hash);
+
+        void setPosition(QueueIndexType indexType, int index);
+
+        Command* buildCommand();
+
+    private:
+        Nullable<SpecialQueueItemType> _queueItemType;
+        QueueIndexType _indexType { QueueIndexType::Normal };
+        int _index { -1 };
+        FileHash _hash;
+    };
+
     class QueueDeleteCommand : public CommandBase
     {
         Q_OBJECT

--- a/src/common/requestid.h
+++ b/src/common/requestid.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2021-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -27,27 +27,27 @@ namespace PMP
     class RequestID
     {
     public:
-        RequestID() : _rawId(0) {}
-        explicit RequestID(uint rawId) : _rawId(rawId) {}
+        constexpr RequestID() : _rawId(0) {}
+        constexpr explicit RequestID(uint rawId) : _rawId(rawId) {}
 
-        bool isValid() const { return _rawId > 0; }
-        uint rawId() const { return _rawId; }
+        constexpr bool isValid() const { return _rawId > 0; }
+        constexpr uint rawId() const { return _rawId; }
 
     private:
         uint _rawId;
     };
 
-    inline bool operator==(const RequestID& me, const RequestID& other)
+    constexpr inline bool operator==(const RequestID& me, const RequestID& other)
     {
         return me.rawId() == other.rawId();
     }
 
-    inline bool operator!=(const RequestID& me, const RequestID& other)
+    constexpr inline bool operator!=(const RequestID& me, const RequestID& other)
     {
         return !(me == other);
     }
 
-    inline uint qHash(const RequestID& requestId)
+    constexpr inline uint qHash(const RequestID& requestId)
     {
         return requestId.rawId();
     }

--- a/src/gui-remote/queuemediator.h
+++ b/src/gui-remote/queuemediator.h
@@ -43,6 +43,11 @@ namespace PMP
 
         QUuid serverUuid() const override;
 
+        bool isQueueLengthKnown() const override
+        {
+            return _sourceMonitor->isQueueLengthKnown();
+        }
+
         int queueLength() const override { return _queueLength; }
         quint32 queueEntry(int index) override;
         QList<quint32> knownQueuePart() const override { return _myQueue; }

--- a/testing/test_commandparser.cpp
+++ b/testing/test_commandparser.cpp
@@ -175,4 +175,67 @@ void TestCommandParser::shutdownCommandDoesNotAcceptArguments()
     verifyParseError({"shutdown", "xyz"});
 }
 
+void TestCommandParser::insertCommandTestValid()
+{
+    const auto hash =
+        "12345-abcdef123456abcdef123456abcdef1234567890-abcdef123456abcdef123456abcdef00";
+
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","break","front"});
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","barrier","front"});
+    verifySuccessfulParsingOf<QueueInsertTrackCommand>({"insert",hash,"front"});
+
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","break","end"});
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","barrier","end"});
+    verifySuccessfulParsingOf<QueueInsertTrackCommand>({"insert",hash,"end"});
+
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","break","index","0"});
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","break","index","12"});
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","barrier","index","0"});
+    verifySuccessfulParsingOf<QueueInsertSpecialItemCommand>({"insert","barrier","index","12"});
+    verifySuccessfulParsingOf<QueueInsertTrackCommand>({"insert",hash,"index","0"});
+    verifySuccessfulParsingOf<QueueInsertTrackCommand>({"insert",hash,"index","12"});
+}
+
+void TestCommandParser::insertCommandTestInvalid()
+{
+    const auto hash =
+        "12345-abcdef123456abcdef123456abcdef1234567890-abcdef123456abcdef123456abcdef00";
+
+    verifyParseError({"insert"});
+
+    verifyParseError({"insert", "xyz"});
+    verifyParseError({"insert", "break"});
+    verifyParseError({"insert", "barrier"});
+    verifyParseError({"insert", hash});
+
+    verifyParseError({"insert", "xyz", "front"});
+    verifyParseError({"insert", "xyz", "end"});
+    verifyParseError({"insert", "xyz", "index"});
+    verifyParseError({"insert", "xyz", "index", "3"});
+
+    verifyParseError({"insert", "break", "xyz"});
+    verifyParseError({"insert", "barrier", "xyz"});
+    verifyParseError({"insert", hash, "xyz"});
+
+    verifyParseError({"insert", "break", "front", "xyz"});
+    verifyParseError({"insert", "barrier", "end", "xyz"});
+    verifyParseError({"insert", hash, "end", "xyz"});
+
+    verifyParseError({"insert", "break", "index"});
+    verifyParseError({"insert", "barrier", "index"});
+    verifyParseError({"insert", hash, "index"});
+
+    verifyParseError({"insert", "break", "index", "xyz"});
+    verifyParseError({"insert", "barrier", "index", "xyz"});
+    verifyParseError({"insert", hash, "index", "xyz"});
+
+    verifyParseError({"insert", "break", "index", "-2"});
+    verifyParseError({"insert", "barrier", "index", "-2"});
+    verifyParseError({"insert", hash, "index", "-2"});
+
+    verifyParseError({"insert", "break", "index", "3", "xyz"});
+    verifyParseError({"insert", "barrier", "index", "3", "xyz"});
+    verifyParseError({"insert", hash, "index", "3", "xyz"});
+}
+
 QTEST_MAIN(TestCommandParser)

--- a/testing/test_commandparser.h
+++ b/testing/test_commandparser.h
@@ -66,5 +66,8 @@ private Q_SLOTS:
 
     void shutdownCommandCanBeParsed();
     void shutdownCommandDoesNotAcceptArguments();
+
+    void insertCommandTestValid();
+    void insertCommandTestInvalid();
 };
 #endif


### PR DESCRIPTION
Add a command to the command-line remote for inserting a track into the queue at a specific position. The track is specified by its hash.

The hash of a track can be obtained with the command-line hash tool or with the 'track info' dialog in the GUI Remote.