### PR TITLE
Refuse insertion of unknown hashes into the queue

### DIFF
--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -1539,6 +1539,7 @@ namespace PMP::Server
                               clientReference);
             return;
         case ResultCode::HashIsNull:
+        case ResultCode::HashIsUnknown:
             sendResultMessage(ResultMessageErrorCode::InvalidHash, clientReference);
             return;
         case ResultCode::QueueEntryIdNotFound:

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -2470,11 +2470,11 @@ namespace PMP::Server
 
         if (messageType == ClientMessageType::AddHashToEndOfQueueRequestMessage)
         {
-            _serverInterface->enqueue(hash);
+            _serverInterface->insertTrackAtEnd(hash);
         }
         else if (messageType == ClientMessageType::AddHashToFrontOfQueueRequestMessage)
         {
-            _serverInterface->insertAtFront(hash);
+            _serverInterface->insertTrackAtFront(hash);
         }
         else
         {

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -2537,10 +2537,7 @@ namespace PMP::Server
 
         qDebug() << " request contains hash:" << hash.dumpToString();
 
-        auto entryCreator = QueueEntryCreators::hash(hash);
-
-        auto result =
-                _serverInterface->insertAtIndex(index, entryCreator, clientReference);
+        auto result = _serverInterface->insertTrack(hash, index, clientReference);
 
         /* success is handled by the queue insertion event, failure is handled here */
         if (!result)

--- a/src/server/hashidregistrar.cpp
+++ b/src/server/hashidregistrar.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -167,6 +167,23 @@ namespace PMP::Server
         }
 
         return result;
+    }
+
+    Nullable<uint> HashIdRegistrar::getIdForHash(FileHash hash)
+    {
+        QMutexLocker lock(&_mutex);
+
+        auto it = _hashes.constFind(hash);
+
+        if (it == _hashes.constEnd())
+            return null;
+
+        return it.value();
+    }
+
+    bool HashIdRegistrar::isRegistered(FileHash hash)
+    {
+        return getIdForHash(hash).hasValue();
     }
 
     Nullable<FileHash> HashIdRegistrar::getHashForId(uint id)

--- a/src/server/hashidregistrar.h
+++ b/src/server/hashidregistrar.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -42,6 +42,8 @@ namespace PMP::Server
         QVector<QPair<uint, FileHash>> getAllLoaded();
         QVector<uint> getAllIdsLoaded();
         QVector<QPair<uint, FileHash>> getExistingIdsOnly(QVector<FileHash> hashes);
+        Nullable<uint> getIdForHash(FileHash hash);
+        bool isRegistered(FileHash hash);
         Nullable<FileHash> getHashForId(uint id);
 
     private:

--- a/src/server/result.h
+++ b/src/server/result.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2021-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -34,6 +34,7 @@ namespace PMP::Server
         OperationAlreadyRunning,
 
         HashIsNull,
+        HashIsUnknown,
 
         QueueEntryIdNotFound,
         QueueIndexOutOfRange,
@@ -107,6 +108,7 @@ namespace PMP::Server
         }
 
         static Result hashIsNull() { return Error(ResultCode::HashIsNull); }
+        static Result hashIsUnknown() { return Error(ResultCode::HashIsUnknown); }
 
         static Result queueEntryIdNotFound(uint id)
         {

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -327,6 +327,13 @@ namespace PMP::Server
         return queue.insertBreakAtFront();
     }
 
+    Result ServerInterface::insertTrack(FileHash hash, int index, quint32 clientReference)
+    {
+        auto entryCreator = QueueEntryCreators::hash(hash);
+
+        return insertAtIndex(index, entryCreator, clientReference);
+    }
+
     Result ServerInterface::insertSpecialQueueItem(SpecialQueueItemType itemType,
                                                    QueueIndexType indexType, int index,
                                                    quint32 clientReference)

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -299,6 +299,9 @@ namespace PMP::Server
         if (!isLoggedIn())
             return Error::notLoggedIn();
 
+        if (_hashIdRegistrar->isRegistered(hash) == false)
+            return Error::hashIsUnknown();
+
         auto& queue = _player->queue();
 
         return queue.enqueue(hash);
@@ -308,6 +311,9 @@ namespace PMP::Server
     {
         if (!isLoggedIn())
             return Error::notLoggedIn();
+
+        if (_hashIdRegistrar->isRegistered(hash) == false)
+            return Error::hashIsUnknown();
 
         auto& queue = _player->queue();
 
@@ -329,6 +335,12 @@ namespace PMP::Server
 
     Result ServerInterface::insertTrack(FileHash hash, int index, quint32 clientReference)
     {
+        if (!isLoggedIn())
+            return Error::notLoggedIn();
+
+        if (_hashIdRegistrar->isRegistered(hash) == false)
+            return Error::hashIsUnknown();
+
         auto entryCreator = QueueEntryCreators::hash(hash);
 
         return insertAtIndex(index, entryCreator, clientReference);
@@ -377,9 +389,6 @@ namespace PMP::Server
                        std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
                        quint32 clientReference)
     {
-        if (!isLoggedIn())
-            return Error::notLoggedIn();
-
         auto& queue = _player->queue();
 
         return queue.insertAtIndex(index, queueEntryCreator,

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -294,7 +294,7 @@ namespace PMP::Server
         return future;
     }
 
-    Result ServerInterface::enqueue(FileHash hash)
+    Result ServerInterface::insertTrackAtEnd(FileHash hash)
     {
         if (!isLoggedIn())
             return Error::notLoggedIn();
@@ -304,7 +304,7 @@ namespace PMP::Server
         return queue.enqueue(hash);
     }
 
-    Result ServerInterface::insertAtFront(FileHash hash)
+    Result ServerInterface::insertTrackAtFront(FileHash hash)
     {
         if (!isLoggedIn())
             return Error::notLoggedIn();

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -104,8 +104,8 @@ namespace PMP::Server
 
         Future<QVector<QString>, Result> getPossibleFilenamesForQueueEntry(uint id);
 
-        Result enqueue(FileHash hash);
-        Result insertAtFront(FileHash hash);
+        Result insertTrackAtEnd(FileHash hash);
+        Result insertTrackAtFront(FileHash hash);
         Result insertBreakAtFrontIfNotExists();
         Result insertSpecialQueueItem(SpecialQueueItemType itemType,
                                       QueueIndexType indexType, int index,

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -107,13 +107,11 @@ namespace PMP::Server
         Result insertTrackAtEnd(FileHash hash);
         Result insertTrackAtFront(FileHash hash);
         Result insertBreakAtFrontIfNotExists();
+        Result insertTrack(FileHash hash, int index, quint32 clientReference);
         Result insertSpecialQueueItem(SpecialQueueItemType itemType,
                                       QueueIndexType indexType, int index,
                                       quint32 clientReference);
         Result duplicateQueueEntry(uint id, quint32 clientReference);
-        Result insertAtIndex(qint32 index,
-                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
-                       quint32 clientReference);
         void moveQueueEntry(uint id, int upDownOffset);
         void removeQueueEntry(uint id);
         void trimQueue();
@@ -170,6 +168,9 @@ namespace PMP::Server
                                 int index);
         std::function<void (uint)> createQueueInsertionIdNotifier(
                                                                  quint32 clientReference);
+        Result insertAtIndex(qint32 index,
+                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
+                       quint32 clientReference);
         void addUserHashDataNotification(quint32 userId, QVector<uint> hashIds);
         void sendUserHashDataNotifications(quint32 userId);
 


### PR DESCRIPTION
When receiving a track insertion request, make sure that the hash is already known to the server. This prevents accidental/malicious registration of fictional/mistyped hashes in the database.