### PR TITLE
Add track filter "no longer available"

### DIFF
--- a/src/gui-remote/collectionwidget.cpp
+++ b/src/gui-remote/collectionwidget.cpp
@@ -322,6 +322,8 @@ namespace PMP
         addItem(tr("not in the queue"), TrackCriterium::NotInTheQueue);
         addItem(tr("in the queue"), TrackCriterium::InTheQueue);
 
+        addItem(tr("no longer available"), TrackCriterium::NoLongerAvailable);
+
         comboBox->setCurrentIndex(0);
     }
 

--- a/src/gui-remote/trackjudge.cpp
+++ b/src/gui-remote/trackjudge.cpp
@@ -80,6 +80,7 @@ namespace PMP
             case TrackCriterium::LengthAtLeastFiveMinutes:
             case TrackCriterium::NotInTheQueue:
             case TrackCriterium::InTheQueue:
+            case TrackCriterium::NoLongerAvailable:
                 break;
         }
 
@@ -159,6 +160,9 @@ namespace PMP
 
             case TrackCriterium::InTheQueue:
                 return _queueHashesMonitor.isPresentInQueue(track.hashId());
+
+            case TrackCriterium::NoLongerAvailable:
+                return track.isAvailable() == false;
         }
 
         return false;

--- a/src/gui-remote/trackjudge.h
+++ b/src/gui-remote/trackjudge.h
@@ -55,6 +55,7 @@ namespace PMP
         LengthAtLeastFiveMinutes,
         NotInTheQueue,
         InTheQueue,
+        NoLongerAvailable,
     };
 
     class TrackJudge


### PR DESCRIPTION
This new filter criterium lists tracks that have disappeared from disk since the server was started. This means that the server has realized that the track's file no longer exists and an alternative file has not been found yet.

NOTE: the server can find tracks that have been moved or renamed on disk, but this currently does not happen automatically. The server will only do this when the track is in the queue, near the front.