### PR TITLE
Add support for album artist

### DIFF
--- a/src/client/collectiontrackinfo.h
+++ b/src/client/collectiontrackinfo.h
@@ -44,9 +44,10 @@ namespace PMP::Client
 
         CollectionTrackInfo(LocalHashId hashId, bool isAvailable,
                             QString const& title, QString const& artist,
-                            QString const& album, qint32 lengthInMilliseconds)
+                            QString const& album, QString const& albumArtist,
+                            qint32 lengthInMilliseconds)
          : _hashId(hashId), _isAvailable(isAvailable), _lengthInMs(lengthInMilliseconds),
-           _title(title), _artist(artist), _album(album)
+            _title(title), _artist(artist), _album(album), _albumArtist(albumArtist)
         {
             //
         }
@@ -59,6 +60,7 @@ namespace PMP::Client
         const QString& title() const { return _title; }
         const QString& artist() const { return _artist; }
         const QString& album() const { return _album; }
+        const QString& albumArtist() const { return _albumArtist; }
         bool lengthIsKnown() const { return _lengthInMs >= 0; }
         qint32 lengthInMilliseconds() const { return _lengthInMs; }
 
@@ -76,7 +78,7 @@ namespace PMP::Client
         LocalHashId _hashId;
         bool _isAvailable;
         qint32 _lengthInMs;
-        QString _title, _artist, _album;
+        QString _title, _artist, _album, _albumArtist;
     };
 
     inline bool operator==(const CollectionTrackInfo& me,
@@ -87,7 +89,8 @@ namespace PMP::Client
             && me.lengthInMilliseconds() == other.lengthInMilliseconds()
             && me.title() == other.title()
             && me.artist() == other.artist()
-            && me.album() == other.album();
+            && me.album() == other.album()
+            && me.albumArtist() == other.albumArtist();
     }
 
     inline bool operator!=(const CollectionTrackInfo& me,

--- a/src/client/collectionwatcher.h
+++ b/src/client/collectionwatcher.h
@@ -33,6 +33,8 @@ namespace PMP::Client
     public:
         virtual ~CollectionWatcher() {}
 
+        virtual bool isAlbumArtistSupported() const = 0;
+
         virtual void enableCollectionDownloading() = 0;
         virtual bool downloadingInProgress() const = 0;
 

--- a/src/client/collectionwatcherimpl.cpp
+++ b/src/client/collectionwatcherimpl.cpp
@@ -20,6 +20,7 @@
 #include "collectionwatcherimpl.h"
 
 #include "collectionfetcher.h"
+#include "servercapabilities.h"
 #include "serverconnection.h"
 
 #include <QtDebug>
@@ -43,6 +44,11 @@ namespace PMP::Client
 
         if (_connection->isConnected())
             onConnected();
+    }
+
+    bool CollectionWatcherImpl::isAlbumArtistSupported() const
+    {
+        return _connection->serverCapabilities().supportsAlbumArtist();
     }
 
     void CollectionWatcherImpl::enableCollectionDownloading()

--- a/src/client/collectionwatcherimpl.h
+++ b/src/client/collectionwatcherimpl.h
@@ -35,6 +35,8 @@ namespace PMP::Client
     public:
         explicit CollectionWatcherImpl(ServerConnection* connection);
 
+        bool isAlbumArtistSupported() const override;
+
         void enableCollectionDownloading() override;
         bool downloadingInProgress() const override;
 

--- a/src/client/servercapabilities.h
+++ b/src/client/servercapabilities.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -34,6 +34,7 @@ namespace PMP::Client
         virtual bool supportsDynamicModeWaveTermination() const = 0;
         virtual bool supportsInsertingBreaksAtAnyIndex() const = 0;
         virtual bool supportsInsertingBarriers() const = 0;
+        virtual bool supportsAlbumArtist() const = 0;
 
     protected:
         ServerCapabilities() {}

--- a/src/client/servercapabilitiesimpl.cpp
+++ b/src/client/servercapabilitiesimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -65,5 +65,10 @@ namespace PMP::Client
     bool ServerCapabilitiesImpl::supportsInsertingBarriers() const
     {
         return _serverProtocolNumber >= 18;
+    }
+
+    bool ServerCapabilitiesImpl::supportsAlbumArtist() const
+    {
+        return _serverProtocolNumber >= 24;
     }
 }

--- a/src/client/servercapabilitiesimpl.h
+++ b/src/client/servercapabilitiesimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -38,6 +38,7 @@ namespace PMP::Client
         bool supportsDynamicModeWaveTermination() const override;
         bool supportsInsertingBreaksAtAnyIndex() const override;
         bool supportsInsertingBarriers() const override;
+        bool supportsAlbumArtist() const override;
 
     private:
         int _serverProtocolNumber;

--- a/src/common/containerutil.h
+++ b/src/common/containerutil.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2021-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,6 +20,7 @@
 #ifndef PMP_CONTAINERUTIL_H
 #define PMP_CONTAINERUTIL_H
 
+#include <QHash>
 #include <QList>
 #include <QSet>
 #include <QVector>
@@ -29,6 +30,18 @@ namespace PMP
     class ContainerUtil
     {
     public:
+        template<typename K, typename V> static QVector<K> keysToVector(
+                                                                   QHash<K,V> const& hash)
+        {
+            QVector<K> v;
+            v.reserve(hash.size());
+
+            for (auto it = hash.keyBegin(); it != hash.keyEnd(); ++it)
+                v.append(*it);
+
+            return v;
+        }
+
         template<typename T> static QVector<T> toVector(QList<T> const& list)
         {
             QVector<T> v;

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -57,6 +57,7 @@ Changes for each version:
   21: single byte request 19, server msg 33: delayed start deadline information
   22: single byte request 60, server msg 34: requesting server version information
   23: server msg 35, error code 241: more features for protocol extensions
+  24: server msgs 18 & 19: add album artist to track info
 */
 
 namespace PMP

--- a/src/common/tagdata.cpp
+++ b/src/common/tagdata.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2021, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -27,9 +27,13 @@ namespace PMP
     }
 
     TagData::TagData(const QString& artist, const QString& title,
-                     const QString& album, const QString& comment)
-     : _artist(artist), _title(title),
-       _album(album), _comment(comment)
+                     const QString& album, const QString& albumArtist,
+                     const QString& comment)
+     : _artist(artist),
+       _title(title),
+       _album(album),
+       _albumArtist(albumArtist),
+       _comment(comment)
     {
         //
     }

--- a/src/common/tagdata.h
+++ b/src/common/tagdata.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -30,11 +30,16 @@ namespace PMP
     public:
         TagData();
         TagData(const QString& artist, const QString& title,
-                const QString& album, const QString& comment);
+                const QString& album, const QString& albumArtist,
+                const QString& comment);
 
         QString artist() const { return _artist; }
         QString title() const { return _title; }
         QString album() const { return _album; }
+
+        QString albumArtist() const { return _albumArtist; }
+        void setAlbumArtist(const QString& albumArtist) { _albumArtist = albumArtist; }
+
         QString comment() const { return _comment; }
 
         bool operator == (TagData const& other) const
@@ -42,6 +47,7 @@ namespace PMP
             return _artist == other._artist
                 && _title == other._title
                 && _album == other._album
+                && _albumArtist == other._albumArtist
                 && _comment == other._comment;
         }
 
@@ -54,6 +60,7 @@ namespace PMP
         QString _artist;
         QString _title;
         QString _album;
+        QString _albumArtist;
         QString _comment;
     };
 }

--- a/src/gui-remote/trackinfodialog.cpp
+++ b/src/gui-remote/trackinfodialog.cpp
@@ -171,6 +171,15 @@ namespace PMP
             }
         );
 
+        if (!_serverInterface->collectionWatcher().isAlbumArtistSupported())
+        {
+            _ui->albumArtistLabel->setVisible(false);
+            _ui->albumArtistValueLabel->setVisible(false);
+            auto* layout = _ui->trackMetadataGroupBox->layout();
+            layout->removeWidget(_ui->albumArtistLabel);
+            layout->removeWidget(_ui->albumArtistValueLabel);
+        }
+
         _userId = _userStatisticsDisplay->userId().valueOr(0);
 
         _serverInterface->authenticationController()
@@ -316,6 +325,7 @@ namespace PMP
         _ui->titleValueLabel->setText(trackInfo.title());
         _ui->artistValueLabel->setText(trackInfo.artist());
         _ui->albumValueLabel->setText(trackInfo.album());
+        _ui->albumArtistValueLabel->setText(trackInfo.albumArtist());
 
         QString lengthText;
         if (trackInfo.lengthIsKnown())
@@ -387,6 +397,7 @@ namespace PMP
         _ui->titleValueLabel->clear();
         _ui->artistValueLabel->clear();
         _ui->albumValueLabel->clear();
+        _ui->albumArtistValueLabel->clear();
         _ui->lengthValueLabel->clear();
     }
 

--- a/src/gui-remote/trackinfodialog.ui
+++ b/src/gui-remote/trackinfodialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>638</width>
-    <height>383</height>
+    <height>419</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -71,7 +71,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="lengthLabel">
         <property name="styleSheet">
          <string notr="true">font-weight: bold</string>
@@ -81,10 +81,27 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QLabel" name="lengthValueLabel">
         <property name="text">
          <string>(length)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="albumArtistLabel">
+        <property name="styleSheet">
+         <string notr="true">font-weight: bold</string>
+        </property>
+        <property name="text">
+         <string>Album artist:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="albumArtistValueLabel">
+        <property name="text">
+         <string>(album artist)</string>
         </property>
        </widget>
       </item>

--- a/src/server/collectionmonitor.h
+++ b/src/server/collectionmonitor.h
@@ -41,7 +41,8 @@ namespace PMP::Server
         void hashBecameAvailable(PMP::FileHash hash);
         void hashBecameUnavailable(PMP::FileHash hash);
         void hashTagInfoChanged(PMP::FileHash hash, QString title, QString artist,
-                                QString album, qint32 lengthInMilliseconds);
+                                QString album, QString albumArtist,
+                                qint32 lengthInMilliseconds);
 
     Q_SIGNALS:
         void hashAvailabilityChanged(QVector<PMP::FileHash> available,
@@ -59,7 +60,7 @@ namespace PMP::Server
         struct HashInfo
         {
             bool isAvailable;
-            QString title, artist, album;
+            QString title, artist, album, albumArtist;
             qint32 lengthInMilliseconds;
 
             HashInfo()

--- a/src/server/collectiontrackinfo.h
+++ b/src/server/collectiontrackinfo.h
@@ -44,9 +44,10 @@ namespace PMP::Server
 
         CollectionTrackInfo(FileHash const& hash, bool isAvailable,
                             QString const& title, QString const& artist,
-                            QString const& album, qint32 lengthInMilliseconds)
+                            QString const& album, QString const& albumArtist,
+                            qint32 lengthInMilliseconds)
          : _hash(hash), _isAvailable(isAvailable), _lengthInMs(lengthInMilliseconds),
-           _title(title), _artist(artist), _album(album)
+            _title(title), _artist(artist), _album(album), _albumArtist(albumArtist)
         {
             //
         }
@@ -59,6 +60,7 @@ namespace PMP::Server
         const QString& title() const { return _title; }
         const QString& artist() const { return _artist; }
         const QString& album() const { return _album; }
+        const QString& albumArtist() const { return _albumArtist; }
         bool lengthIsKnown() const { return _lengthInMs >= 0; }
         qint32 lengthInMilliseconds() const { return _lengthInMs; }
 
@@ -76,7 +78,7 @@ namespace PMP::Server
         FileHash _hash;
         bool _isAvailable;
         qint32 _lengthInMs;
-        QString _title, _artist, _album;
+        QString _title, _artist, _album, _albumArtist;
     };
 
     inline bool operator==(const CollectionTrackInfo& me,
@@ -87,7 +89,8 @@ namespace PMP::Server
             && me.lengthInMilliseconds() == other.lengthInMilliseconds()
             && me.title() == other.title()
             && me.artist() == other.artist()
-            && me.album() == other.album();
+            && me.album() == other.album()
+            && me.albumArtist() == other.albumArtist();
     }
 
     inline bool operator!=(const CollectionTrackInfo& me,

--- a/src/server/queueentry.cpp
+++ b/src/server/queueentry.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -125,7 +125,10 @@ namespace PMP::Server
 
         if (!_audioInfo.isComplete())
         {
-            _audioInfo = resolver.findAudioData(_hash);
+            auto audioDataFound = resolver.findAudioData(_hash);
+
+            if (audioDataFound.hasValue())
+                _audioInfo = audioDataFound.value();
         }
     }
 
@@ -137,10 +140,10 @@ namespace PMP::Server
 
         if (_fetchedTagData) return;
 
-        const TagData* tag = resolver.findTagData(_hash);
-        if (tag)
+        auto tagDataFound = resolver.findTagData(_hash);
+        if (tagDataFound.hasValue())
         {
-            _tagData = *tag;
+            _tagData = tagDataFound.value();
             _fetchedTagData = true;
         }
     }

--- a/src/server/resolver.cpp
+++ b/src/server/resolver.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -430,6 +430,7 @@ namespace PMP::Server
         QString _quickTitle;
         QString _quickArtist;
         QString _quickAlbum;
+        QString _quickAlbumArtist;
 
     public:
         HashKnowledge(Resolver* parent, FileHash hash, uint hashId)
@@ -454,6 +455,7 @@ namespace PMP::Server
         QString quickTitle() { return _quickTitle; }
         QString quickArtist() { return _quickArtist; }
         QString quickAlbum() { return _quickAlbum; }
+        QString quickAlbumArtist() { return _quickAlbumArtist; }
 
         void addPath(const QString& filename,
                      qint64 fileSize, QDateTime fileLastModified, uint indexationNumber);
@@ -511,7 +513,8 @@ namespace PMP::Server
         {
             if (existing->title() == t.title()
                     && existing->artist() == t.artist()
-                    && existing->album() == t.album())
+                    && existing->album() == t.album()
+                    && existing->albumArtist() == t.albumArtist())
             {
                 tagIsNew = false;
                 break;
@@ -526,25 +529,29 @@ namespace PMP::Server
             auto tags = findBestTag();
             if (tags)
             {
-                QString oldQuickTitle = _quickTitle;
-                QString oldQuickArtist = _quickArtist;
-                QString oldQuickAlbum = _quickAlbum;
+                auto oldQuickTitle = _quickTitle;
+                auto oldQuickArtist = _quickArtist;
+                auto oldQuickAlbum = _quickAlbum;
+                auto oldQuickAlbumArtist = _quickAlbumArtist;
 
                 _quickTitle = tags->title();
                 _quickArtist = tags->artist();
                 _quickAlbum = tags->album();
+                _quickAlbumArtist = tags->albumArtist();
 
                 quickTagsChanged =
                         oldQuickTitle != _quickTitle
                             || oldQuickArtist != _quickArtist
-                            || oldQuickAlbum != _quickAlbum;
+                            || oldQuickAlbum != _quickAlbum
+                            || oldQuickAlbumArtist != _quickAlbumArtist;
 
                 if (_tags.size() > 1 && !quickTagsChanged)
                 {
                     qDebug() << "extra tag added for track but not switching away from"
                              << " old tag info: title:" << oldQuickTitle
                              << "; artist:" << oldQuickArtist
-                             << "; album:" << oldQuickAlbum;
+                             << "; album:" << oldQuickAlbum
+                             << "; album artist:" << oldQuickAlbumArtist;
                 }
             }
         }
@@ -552,7 +559,7 @@ namespace PMP::Server
         if (lengthChanged || quickTagsChanged)
         {
             Q_EMIT _parent->hashTagInfoChanged(_hash, _quickTitle, _quickArtist,
-                                               _quickAlbum,
+                                               _quickAlbum, _quickAlbumArtist,
                                                _audio.trackLengthMilliseconds());
         }
     }
@@ -569,6 +576,7 @@ namespace PMP::Server
             int titleLength = tag->title().length();
             int artistLength = tag->artist().length();
             int albumLength = tag->album().length();
+            int albumArtistLength = tag->albumArtist().length();
 
             if (titleLength > 0)
             {
@@ -586,6 +594,11 @@ namespace PMP::Server
             {
                 score += 6000;
                 score += std::min(albumLength, 256);
+            }
+
+            if (albumArtistLength > 0)
+            {
+                score += 1000;
             }
 
             /* for equal scores we'll use the latest tag */
@@ -1111,24 +1124,31 @@ namespace PMP::Server
         (void)knowledge->isStillValid(file);
     }
 
-    const AudioData& Resolver::findAudioData(const FileHash& hash)
+    Nullable<AudioData> Resolver::findAudioData(const FileHash& hash)
     {
         QMutexLocker lock(&_lock);
 
         auto knowledge = _hashKnowledge.value(hash, nullptr);
         if (knowledge) return knowledge->audio();
 
-        return _emptyAudioData; /* we could not register the hash */
+        return null;
     }
 
-    const TagData* Resolver::findTagData(const FileHash& hash)
+    Nullable<TagData> Resolver::findTagData(const FileHash& hash)
     {
         QMutexLocker lock(&_lock);
 
         auto knowledge = _hashKnowledge.value(hash, nullptr);
-        if (knowledge) return knowledge->findBestTag();
 
-        return nullptr;
+        if (knowledge)
+        {
+            const auto* bestTag = knowledge->findBestTag();
+
+            if (bestTag)
+                return *bestTag;
+        }
+
+        return null;
     }
 
     QVector<FileHash> Resolver::getAllHashes()
@@ -1159,6 +1179,7 @@ namespace PMP::Server
             CollectionTrackInfo info(hash, knowledge->isAvailable(),
                                      knowledge->quickTitle(), knowledge->quickArtist(),
                                      knowledge->quickAlbum(),
+                                     knowledge->quickAlbumArtist(),
                                      (qint32)lengthInMilliseconds);
 
             result.append(info);

--- a/src/server/resolver.h
+++ b/src/server/resolver.h
@@ -23,6 +23,7 @@
 #include "common/audiodata.h"
 #include "common/filehash.h"
 #include "common/future.h"
+#include "common/nullable.h"
 #include "common/tagdata.h"
 
 #include "analyzer.h"
@@ -117,8 +118,8 @@ namespace PMP::Server
         bool pathStillValid(const FileHash& hash, QString path);
         Nullable<FileHash> getHashForFilePath(QString path);
 
-        const AudioData& findAudioData(const FileHash& hash);
-        const TagData* findTagData(const FileHash& hash);
+        Nullable<AudioData> findAudioData(const FileHash& hash);
+        Nullable<TagData> findTagData(const FileHash& hash);
 
         QVector<FileHash> getAllHashes();
         QVector<CollectionTrackInfo> getHashesTrackInfo(QVector<FileHash> hashes);
@@ -140,7 +141,8 @@ namespace PMP::Server
         void hashBecameAvailable(PMP::FileHash hash);
         void hashBecameUnavailable(PMP::FileHash hash);
         void hashTagInfoChanged(PMP::FileHash hash, QString title, QString artist,
-                                QString album, qint32 lengthInMilliseconds);
+                                QString album, QString albumArtist,
+                                qint32 lengthInMilliseconds);
 
     private:
         enum class FullIndexationStatus
@@ -180,8 +182,6 @@ namespace PMP::Server
 
         uint _fullIndexationNumber;
         FullIndexationStatus _fullIndexationStatus;
-
-        AudioData _emptyAudioData;
     };
 }
 #endif

--- a/src/server/trackgeneratorbase.cpp
+++ b/src/server/trackgeneratorbase.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -140,9 +140,10 @@ namespace PMP::Server
             return nullptr;
         }
 
-        const AudioData& audioData = _resolver->findAudioData(hash);
+        auto audioDataFound = _resolver->findAudioData(hash);
 
-        return QSharedPointer<Candidate>::create(_source, id, hash, audioData,
+        return QSharedPointer<Candidate>::create(_source, id, hash,
+                                                 audioDataFound.valueOr({}),
                                                  getRandomPermillage());
     }
 

--- a/src/tools/hash-main.cpp
+++ b/src/tools/hash-main.cpp
@@ -102,6 +102,7 @@ int main(int argc, char *argv[])
     out << "       title: " << analyzer.tagData().title() << Qt::endl;
     out << "      artist: " << analyzer.tagData().artist() << Qt::endl;
     out << "       album: " << analyzer.tagData().album() << Qt::endl;
+    out << "album artist: " << analyzer.tagData().albumArtist() << Qt::endl;
     out << "     comment: " << analyzer.tagData().comment() << Qt::endl;
 
     out << "  track hash: " << finalHash.toString() << Qt::endl;


### PR DESCRIPTION
For MP3 files, album artist is read from the TPE2 frame of the ID3v2 tag.

The desktop client will display album artist in the "track info" dialog. Album artist is hidden in that dialog if connected to an older server that does not support album artist.

The hash tool will print album artist between album and comment.

During development I have noticed that most of my music files do not contain album artist information. Exact Audio Copy does not seem to add it by default.