### PR TITLE
Bugfix: track update causes client crash

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -35,6 +35,7 @@ KNOWN PROBLEMS
  * track title/artist/length update in the music collection does not trigger an update of queue entries referencing that track
  * doing a "skip" often creates a burst of noise; need to wait until the old track has stopped before starting the next one
  * GUI remote: if connection breaks during playback, "position" keeps increasing
+ * server does not always take an updated title/artist/album into account when a track is changed on disk
 
 
 PERFORMANCE ISSUES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,6 +257,12 @@ target_link_libraries(PmpClient Qt5::Core Qt5::Network)
 add_library(PmpCmdRemote OBJECT ${PMP_CMD_REMOTE_SOURCES} ${PMP_CMD_REMOTE_MOCS})
 target_link_libraries(PmpCmdRemote Qt5::Core Qt5::Network)
 
+add_library(PmpGuiRemote OBJECT
+    ${PMP_GUI_REMOTE_SOURCES} ${PMP_GUI_REMOTE_MOCS}
+    ${PMP_GUI_REMOTE_UICS} ${PMP_GUI_REMOTE_QRCS}
+)
+target_link_libraries(PmpGuiRemote Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets)
+
 add_library(PmpServer OBJECT ${PMP_SERVER_SOURCES} ${PMP_SERVER_MOCS})
 target_link_libraries(PmpServer Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
 
@@ -296,11 +302,10 @@ target_link_libraries(PMP-Cmd-Remote
 add_executable(PMP-GUI-Remote
     ${PMP_WIN32_FLAG}
     gui-remote/gui-remote-main.cpp
-    ${PMP_GUI_REMOTE_SOURCES} ${PMP_GUI_REMOTE_MOCS}
-    ${PMP_GUI_REMOTE_UICS}
-    ${PMP_GUI_REMOTE_QRCS}
+
 )
 target_link_libraries(PMP-GUI-Remote
+    $<TARGET_OBJECTS:PmpGuiRemote>
     $<TARGET_OBJECTS:PmpClient>
     $<TARGET_OBJECTS:PmpCommon>
 )

--- a/src/client/collectiontrackinfo.h
+++ b/src/client/collectiontrackinfo.h
@@ -57,7 +57,9 @@ namespace PMP::Client
         void setAvailable(bool available) { _isAvailable = available; }
         bool isAvailable() const { return _isAvailable; }
 
+        void setTitle(QString title) { _title = title; }
         const QString& title() const { return _title; }
+
         const QString& artist() const { return _artist; }
         const QString& album() const { return _album; }
         const QString& albumArtist() const { return _albumArtist; }

--- a/src/client/collectionwatcher.h
+++ b/src/client/collectionwatcher.h
@@ -48,7 +48,7 @@ namespace PMP::Client
         void trackDataChanged(CollectionTrackInfo track);
 
     protected:
-        explicit CollectionWatcher(QObject* parent) : QObject(parent) {}
+        explicit CollectionWatcher(QObject* parent = nullptr) : QObject(parent) {}
     };
 }
 #endif

--- a/src/client/currenttrackmonitor.h
+++ b/src/client/currenttrackmonitor.h
@@ -59,7 +59,7 @@ namespace PMP::Client
                                   qint64 trackLengthInMilliseconds);
 
     protected:
-        explicit CurrentTrackMonitor(QObject* parent) : QObject(parent) {}
+        explicit CurrentTrackMonitor(QObject* parent = nullptr) : QObject(parent) {}
     };
 }
 #endif

--- a/src/client/playercontroller.h
+++ b/src/client/playercontroller.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2017-2023, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -80,7 +80,7 @@ namespace PMP::Client
         void delayedStartActiveInfoChanged();
 
     protected:
-        explicit PlayerController(QObject* parent) : QObject(parent) {}
+        explicit PlayerController(QObject* parent = nullptr) : QObject(parent) {}
     };
 }
 #endif

--- a/src/client/queuehashesmonitor.h
+++ b/src/client/queuehashesmonitor.h
@@ -36,7 +36,7 @@ namespace PMP::Client
     {
         Q_OBJECT
     protected:
-        explicit QueueHashesMonitor(QObject* parent = nullptr) {}
+        explicit QueueHashesMonitor(QObject* parent = nullptr) : QObject(parent) {}
     public:
         virtual ~QueueHashesMonitor() {}
 

--- a/src/client/userdatafetcher.h
+++ b/src/client/userdatafetcher.h
@@ -37,7 +37,7 @@ namespace PMP::Client
     {
         Q_OBJECT
     protected:
-        explicit UserDataFetcher(QObject* parent = nullptr) {}
+        explicit UserDataFetcher(QObject* parent = nullptr) : QObject(parent) {}
     public:
         virtual ~UserDataFetcher() {}
 

--- a/src/gui-remote/collectiontablemodel.h
+++ b/src/gui-remote/collectiontablemodel.h
@@ -65,6 +65,7 @@ namespace PMP
 
         Client::CollectionTrackInfo const* trackAt(const QModelIndex& index) const;
         Client::CollectionTrackInfo const* trackAt(int rowIndex) const;
+        int trackIndex(Client::LocalHashId hashId) const;
 
         int rowCount(const QModelIndex& parent = QModelIndex()) const;
         int columnCount(const QModelIndex& parent = QModelIndex()) const;
@@ -100,6 +101,7 @@ namespace PMP
         int findOuterIndexMapIndexForInsert(Client::CollectionTrackInfo const& track,
                                             int searchRangeBegin, int searchRangeEnd);
         int findOuterIndexForHash(Client::LocalHashId hashId);
+        void markRowAsChanged(int index);
         void markLeftColumnAsChanged();
         void markEverythingAsChanged();
 

--- a/src/gui-remote/userforstatisticsdisplay.h
+++ b/src/gui-remote/userforstatisticsdisplay.h
@@ -35,7 +35,7 @@ namespace PMP
     {
         Q_OBJECT
     protected:
-        explicit UserForStatisticsDisplay(QObject* parent = nullptr) {}
+        explicit UserForStatisticsDisplay(QObject* parent = nullptr) : QObject(parent) {}
     public:
         virtual ~UserForStatisticsDisplay() {}
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -140,4 +140,5 @@ target_link_libraries(test_sortedcollectiontablemodel $<TARGET_OBJECTS:PmpCommon
 target_link_libraries(test_sortedcollectiontablemodel Qt5::Gui Qt5::Widgets)
 target_link_libraries(test_sortedcollectiontablemodel Qt5::Core Qt5::Network Qt5::Test)
 target_link_libraries(test_sortedcollectiontablemodel ${TAGLIB_LIBRARIES})
-add_test(test_sortedcollectiontablemodel test_sortedcollectiontablemodel)
+add_test(NAME test_sortedcollectiontablemodel
+         COMMAND test_sortedcollectiontablemodel -platform offscreen)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -127,3 +127,17 @@ add_executable(test_hashrelations test_hashrelations.cpp
 )
 target_link_libraries(test_hashrelations Qt5::Core Qt5::Test)
 add_test(test_hashrelations test_hashrelations)
+
+
+# TestSortedCollectionTableModel
+qt5_wrap_cpp(PMP_TestSortedCollectionTableModel_MOCS test_sortedcollectiontablemodel.h)
+add_executable(test_sortedcollectiontablemodel test_sortedcollectiontablemodel.cpp
+    ${PMP_TestSortedCollectionTableModel_MOCS}
+)
+target_link_libraries(test_sortedcollectiontablemodel $<TARGET_OBJECTS:PmpGuiRemote>)
+target_link_libraries(test_sortedcollectiontablemodel $<TARGET_OBJECTS:PmpClient>)
+target_link_libraries(test_sortedcollectiontablemodel $<TARGET_OBJECTS:PmpCommon>)
+target_link_libraries(test_sortedcollectiontablemodel Qt5::Gui Qt5::Widgets)
+target_link_libraries(test_sortedcollectiontablemodel Qt5::Core Qt5::Network Qt5::Test)
+target_link_libraries(test_sortedcollectiontablemodel ${TAGLIB_LIBRARIES})
+add_test(test_sortedcollectiontablemodel test_sortedcollectiontablemodel)

--- a/testing/test_sortedcollectiontablemodel.cpp
+++ b/testing/test_sortedcollectiontablemodel.cpp
@@ -1,0 +1,660 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "test_sortedcollectiontablemodel.h"
+
+#include "client/localhashidrepository.h"
+
+#include "gui-remote/collectiontablemodel.h"
+
+#include <QtTest/QTest>
+
+using namespace PMP;
+using namespace PMP::Client;
+
+namespace
+{
+    CollectionTrackInfo createTrack(int hashId, QString title, QString artist)
+    {
+        return CollectionTrackInfo(LocalHashId(hashId), true, title, artist, "", "",
+                                   3 * 60 * 1000);
+    }
+
+    void logRowMovements(SortedCollectionTableModel& model, QString* output)
+    {
+        QObject::connect(
+            &model, &SortedCollectionTableModel::rowsMoved,
+            [output](const QModelIndex& sourceParent, int sourceStart, int sourceEnd,
+                     const QModelIndex& destinationParent, int destinationRow)
+            {
+                QString s = "M";
+                s += QString::number(sourceStart);
+                s += "-";
+                s += QString::number(sourceEnd);
+                s += ">";
+                s += QString::number(destinationRow);
+                s += ";";
+
+                *output += s;
+            }
+        );
+    }
+
+    void verifyInnerToOuterMapping(SortedCollectionTableModel& model)
+    {
+        for (int rowIndex = 0; rowIndex < model.rowCount(); ++rowIndex)
+        {
+            auto* track = model.trackAt(rowIndex);
+
+            auto index = model.trackIndex(track->hashId());
+
+            QCOMPARE(index, rowIndex);
+        }
+    }
+}
+
+void TestSortedCollectionTableModel::trackTitleUpdateCausesMoveUpward()
+{
+    PlayerControllerMock playerController;
+    CurrentTrackMonitorMock currentTrackMonitor;
+    QueueHashesMonitorMock queueHashesMonitor;
+    UserForStatisticsDisplayMock userForStatisticsDisplay;
+    UserDataFetcherMock userDataFetcher;
+    CollectionWatcherMock collectionWatcher;
+
+    collectionWatcher.addTrack(createTrack(1, "B", "B"));
+    collectionWatcher.addTrack(createTrack(2, "D", "D"));
+    collectionWatcher.addTrack(createTrack(3, "F", "F"));
+    collectionWatcher.addTrack(createTrack(4, "H", "H"));
+    collectionWatcher.addTrack(createTrack(5, "K", "K"));
+
+    ServerInterfaceMock serverInterface;
+    serverInterface.setUserDataFetcher(&userDataFetcher);
+    serverInterface.setPlayerController(&playerController);
+    serverInterface.setCollectionWatcher(&collectionWatcher);
+    serverInterface.setCurrentTrackMonitor(&currentTrackMonitor);
+
+    SortedCollectionTableModel model(nullptr, &serverInterface, &queueHashesMonitor,
+                                     &userForStatisticsDisplay);
+
+    QString movements;
+    logRowMovements(model, &movements);
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "D");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+
+    collectionWatcher.modifyTrackTitle(LocalHashId(2), "A");
+
+    QCOMPARE(movements, "M1-1>0;");
+
+    QCOMPARE(model.trackAt(0)->title(), "A");
+    QCOMPARE(model.trackAt(1)->title(), "B");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+}
+
+void TestSortedCollectionTableModel::trackTitleUpdateCausesNoMove_v1()
+{
+    PlayerControllerMock playerController;
+    CurrentTrackMonitorMock currentTrackMonitor;
+    QueueHashesMonitorMock queueHashesMonitor;
+    UserForStatisticsDisplayMock userForStatisticsDisplay;
+    UserDataFetcherMock userDataFetcher;
+    CollectionWatcherMock collectionWatcher;
+
+    collectionWatcher.addTrack(createTrack(1, "B", "B"));
+    collectionWatcher.addTrack(createTrack(2, "D", "D"));
+    collectionWatcher.addTrack(createTrack(3, "F", "F"));
+    collectionWatcher.addTrack(createTrack(4, "H", "H"));
+    collectionWatcher.addTrack(createTrack(5, "K", "K"));
+
+    ServerInterfaceMock serverInterface;
+    serverInterface.setUserDataFetcher(&userDataFetcher);
+    serverInterface.setPlayerController(&playerController);
+    serverInterface.setCollectionWatcher(&collectionWatcher);
+    serverInterface.setCurrentTrackMonitor(&currentTrackMonitor);
+
+    SortedCollectionTableModel model(nullptr, &serverInterface, &queueHashesMonitor,
+                                     &userForStatisticsDisplay);
+
+    QString movements;
+    logRowMovements(model, &movements);
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "D");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+
+    collectionWatcher.modifyTrackTitle(LocalHashId(2), "C");
+
+    QCOMPARE(movements, "");
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "C");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+}
+
+void TestSortedCollectionTableModel::trackTitleUpdateCausesNoMove_v2()
+{
+    PlayerControllerMock playerController;
+    CurrentTrackMonitorMock currentTrackMonitor;
+    QueueHashesMonitorMock queueHashesMonitor;
+    UserForStatisticsDisplayMock userForStatisticsDisplay;
+    UserDataFetcherMock userDataFetcher;
+    CollectionWatcherMock collectionWatcher;
+
+    collectionWatcher.addTrack(createTrack(1, "B", "B"));
+    collectionWatcher.addTrack(createTrack(2, "D", "D"));
+    collectionWatcher.addTrack(createTrack(3, "F", "F"));
+    collectionWatcher.addTrack(createTrack(4, "H", "H"));
+    collectionWatcher.addTrack(createTrack(5, "K", "K"));
+
+    ServerInterfaceMock serverInterface;
+    serverInterface.setUserDataFetcher(&userDataFetcher);
+    serverInterface.setPlayerController(&playerController);
+    serverInterface.setCollectionWatcher(&collectionWatcher);
+    serverInterface.setCurrentTrackMonitor(&currentTrackMonitor);
+
+    SortedCollectionTableModel model(nullptr, &serverInterface, &queueHashesMonitor,
+                                     &userForStatisticsDisplay);
+
+    QString movements;
+    logRowMovements(model, &movements);
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "D");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+
+    collectionWatcher.modifyTrackTitle(LocalHashId(2), "E");
+
+    QCOMPARE(movements, "");
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "E");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+}
+
+void TestSortedCollectionTableModel::trackTitleUpdateCausesMoveDownward()
+{
+    PlayerControllerMock playerController;
+    CurrentTrackMonitorMock currentTrackMonitor;
+    QueueHashesMonitorMock queueHashesMonitor;
+    UserForStatisticsDisplayMock userForStatisticsDisplay;
+    UserDataFetcherMock userDataFetcher;
+    CollectionWatcherMock collectionWatcher;
+
+    collectionWatcher.addTrack(createTrack(1, "B", "B"));
+    collectionWatcher.addTrack(createTrack(2, "D", "D"));
+    collectionWatcher.addTrack(createTrack(3, "F", "F"));
+    collectionWatcher.addTrack(createTrack(4, "H", "H"));
+    collectionWatcher.addTrack(createTrack(5, "K", "K"));
+
+    ServerInterfaceMock serverInterface;
+    serverInterface.setUserDataFetcher(&userDataFetcher);
+    serverInterface.setPlayerController(&playerController);
+    serverInterface.setCollectionWatcher(&collectionWatcher);
+    serverInterface.setCurrentTrackMonitor(&currentTrackMonitor);
+
+    SortedCollectionTableModel model(nullptr, &serverInterface, &queueHashesMonitor,
+                                     &userForStatisticsDisplay);
+
+    QString movements;
+    logRowMovements(model, &movements);
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "D");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+
+    collectionWatcher.modifyTrackTitle(LocalHashId(2), "G");
+
+    QCOMPARE(movements, "M1-1>3;");
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "F");
+    QCOMPARE(model.trackAt(2)->title(), "G");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    verifyInnerToOuterMapping(model);
+}
+
+void TestSortedCollectionTableModel::trackTitleUpdateCausesMoveToLastPosition()
+{
+    PlayerControllerMock playerController;
+    CurrentTrackMonitorMock currentTrackMonitor;
+    QueueHashesMonitorMock queueHashesMonitor;
+    UserForStatisticsDisplayMock userForStatisticsDisplay;
+    UserDataFetcherMock userDataFetcher;
+    CollectionWatcherMock collectionWatcher;
+
+    collectionWatcher.addTrack(createTrack(1, "B", "B"));
+    collectionWatcher.addTrack(createTrack(2, "D", "D"));
+    collectionWatcher.addTrack(createTrack(3, "F", "F"));
+    collectionWatcher.addTrack(createTrack(4, "H", "H"));
+    collectionWatcher.addTrack(createTrack(5, "K", "K"));
+
+    ServerInterfaceMock serverInterface;
+    serverInterface.setUserDataFetcher(&userDataFetcher);
+    serverInterface.setPlayerController(&playerController);
+    serverInterface.setCollectionWatcher(&collectionWatcher);
+    serverInterface.setCurrentTrackMonitor(&currentTrackMonitor);
+
+    SortedCollectionTableModel model(nullptr, &serverInterface, &queueHashesMonitor,
+                                     &userForStatisticsDisplay);
+
+    QString movements;
+    logRowMovements(model, &movements);
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "D");
+    QCOMPARE(model.trackAt(2)->title(), "F");
+    QCOMPARE(model.trackAt(3)->title(), "H");
+    QCOMPARE(model.trackAt(4)->title(), "K");
+    verifyInnerToOuterMapping(model);
+
+    collectionWatcher.modifyTrackTitle(LocalHashId(2), "L");
+
+    QCOMPARE(movements, "M1-1>5;");
+
+    QCOMPARE(model.trackAt(0)->title(), "B");
+    QCOMPARE(model.trackAt(1)->title(), "F");
+    QCOMPARE(model.trackAt(2)->title(), "H");
+    QCOMPARE(model.trackAt(3)->title(), "K");
+    QCOMPARE(model.trackAt(4)->title(), "L");
+    verifyInnerToOuterMapping(model);
+}
+
+#define NOT_IMPLEMENTED { Q_UNREACHABLE(); }
+
+/* =========== */
+
+PlayerState PlayerControllerMock::playerState() const
+{
+    return PlayerState::Stopped;
+}
+
+TriBool PlayerControllerMock::delayedStartActive() const
+{
+    NOT_IMPLEMENTED
+}
+
+TriBool PlayerControllerMock::isTrackPresent() const
+{
+    NOT_IMPLEMENTED
+}
+
+quint32 PlayerControllerMock::currentQueueId() const
+{
+    NOT_IMPLEMENTED
+}
+
+uint PlayerControllerMock::queueLength() const
+{
+    NOT_IMPLEMENTED
+}
+
+bool PlayerControllerMock::canPlay() const
+{
+    NOT_IMPLEMENTED
+}
+
+bool PlayerControllerMock::canPause() const
+{
+    NOT_IMPLEMENTED
+}
+
+bool PlayerControllerMock::canSkip() const
+{
+    NOT_IMPLEMENTED
+}
+
+PlayerMode PlayerControllerMock::playerMode() const
+{
+    NOT_IMPLEMENTED
+}
+
+quint32 PlayerControllerMock::personalModeUserId() const
+{
+    NOT_IMPLEMENTED
+}
+
+QString PlayerControllerMock::personalModeUserLogin() const
+{
+    NOT_IMPLEMENTED
+}
+
+int PlayerControllerMock::volume() const
+{
+    NOT_IMPLEMENTED
+}
+
+QDateTime PlayerControllerMock::delayedStartServerDeadline()
+{
+    NOT_IMPLEMENTED
+}
+
+SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::activateDelayedStart(qint64 delayMilliseconds)
+{
+    NOT_IMPLEMENTED
+}
+
+SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::activateDelayedStart(QDateTime startTime)
+{
+    NOT_IMPLEMENTED
+}
+
+SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::deactivateDelayedStart()
+{
+    NOT_IMPLEMENTED
+}
+
+void PlayerControllerMock::play()
+{
+    NOT_IMPLEMENTED
+}
+
+void PlayerControllerMock::pause()
+{
+    NOT_IMPLEMENTED
+}
+
+void PlayerControllerMock::skip()
+{
+    NOT_IMPLEMENTED
+}
+
+void PlayerControllerMock::setVolume(int volume)
+{
+    NOT_IMPLEMENTED
+}
+
+void PlayerControllerMock::switchToPublicMode()
+{
+    NOT_IMPLEMENTED
+}
+
+void PlayerControllerMock::switchToPersonalMode()
+{
+    NOT_IMPLEMENTED
+}
+
+/* =========== */
+
+PlayerState CurrentTrackMonitorMock::playerState() const
+{
+    return PlayerState::Stopped;
+}
+
+TriBool CurrentTrackMonitorMock::isTrackPresent() const
+{
+    NOT_IMPLEMENTED
+}
+
+quint32 CurrentTrackMonitorMock::currentQueueId() const
+{
+    NOT_IMPLEMENTED
+}
+
+qint64 CurrentTrackMonitorMock::currentTrackProgressMilliseconds() const
+{
+    NOT_IMPLEMENTED
+}
+
+LocalHashId CurrentTrackMonitorMock::currentTrackHash() const
+{
+    return {};
+}
+
+QString CurrentTrackMonitorMock::currentTrackTitle() const
+{
+    NOT_IMPLEMENTED
+}
+
+QString CurrentTrackMonitorMock::currentTrackArtist() const
+{
+    NOT_IMPLEMENTED
+}
+
+QString CurrentTrackMonitorMock::currentTrackPossibleFilename() const
+{
+    NOT_IMPLEMENTED
+}
+
+qint64 CurrentTrackMonitorMock::currentTrackLengthMilliseconds() const
+{
+    NOT_IMPLEMENTED
+}
+
+void CurrentTrackMonitorMock::seekTo(qint64 positionInMilliseconds)
+{
+    NOT_IMPLEMENTED
+}
+
+/* =========== */
+
+bool QueueHashesMonitorMock::isPresentInQueue(PMP::Client::LocalHashId hashId) const
+{
+    return false;
+}
+
+/* =========== */
+
+PMP::Nullable<quint32> UserForStatisticsDisplayMock::userId() const
+{
+    return 1;
+}
+
+PMP::Nullable<bool> UserForStatisticsDisplayMock::isPersonal() const
+{
+    return true;
+}
+
+void UserForStatisticsDisplayMock::setPersonal()
+{
+    //
+}
+
+void UserForStatisticsDisplayMock::setPublic()
+{
+    //
+}
+
+/* =========== */
+
+void UserDataFetcherMock::enableAutoFetchForUser(quint32 userId)
+{
+    //
+}
+
+const UserDataFetcher::HashData* UserDataFetcherMock::getHashDataForUser(quint32 userId,
+                                                                       LocalHashId hashId)
+{
+    NOT_IMPLEMENTED
+}
+
+/* =========== */
+
+void CollectionWatcherMock::addTrack(CollectionTrackInfo track)
+{
+    _collection.insert(track.hashId(), track);
+}
+
+void CollectionWatcherMock::modifyTrackTitle(LocalHashId id, QString title)
+{
+    auto it = _collection.find(id);
+    if (it == _collection.end())
+        return;
+
+    it.value().setTitle(title);
+    Q_EMIT trackDataChanged(it.value());
+}
+
+bool CollectionWatcherMock::isAlbumArtistSupported() const
+{
+    NOT_IMPLEMENTED
+}
+
+void CollectionWatcherMock::enableCollectionDownloading()
+{
+    //
+}
+
+bool CollectionWatcherMock::downloadingInProgress() const
+{
+    NOT_IMPLEMENTED
+}
+
+QHash<LocalHashId, CollectionTrackInfo> CollectionWatcherMock::getCollection()
+{
+    return _collection;
+}
+
+CollectionTrackInfo CollectionWatcherMock::getTrack(LocalHashId hashId)
+{
+    NOT_IMPLEMENTED
+}
+
+/* =========== */
+
+ServerInterfaceMock::ServerInterfaceMock()
+    : _localHashIdRepository(new LocalHashIdRepository())
+{
+    //
+}
+
+void ServerInterfaceMock::setUserDataFetcher(UserDataFetcher* userDataFetcher)
+{
+    _userDataFetcher = userDataFetcher;
+}
+
+void ServerInterfaceMock::setPlayerController(PlayerController* playerController)
+{
+    _playerController = playerController;
+}
+
+void ServerInterfaceMock::setCollectionWatcher(CollectionWatcher* collectionWatcher)
+{
+    _collectionWatcher = collectionWatcher;
+}
+
+void ServerInterfaceMock::setCurrentTrackMonitor(CurrentTrackMonitor* currentTrackMonitor)
+{
+    _currentTrackMonitor = currentTrackMonitor;
+}
+
+PMP::Client::LocalHashIdRepository* ServerInterfaceMock::hashIdRepository() const
+{
+    return _localHashIdRepository;
+}
+
+AuthenticationController& ServerInterfaceMock::authenticationController()
+{
+    NOT_IMPLEMENTED
+}
+
+GeneralController& ServerInterfaceMock::generalController()
+{
+    NOT_IMPLEMENTED
+}
+
+PlayerController& ServerInterfaceMock::playerController()
+{
+    if (_playerController) return *_playerController;
+
+    Q_UNREACHABLE();
+}
+
+CurrentTrackMonitor& ServerInterfaceMock::currentTrackMonitor()
+{
+    if (_currentTrackMonitor) return *_currentTrackMonitor;
+
+    Q_UNREACHABLE();
+}
+
+QueueController& ServerInterfaceMock::queueController()
+{
+    NOT_IMPLEMENTED
+}
+
+AbstractQueueMonitor& ServerInterfaceMock::queueMonitor()
+{
+    NOT_IMPLEMENTED
+}
+
+QueueEntryInfoStorage& ServerInterfaceMock::queueEntryInfoStorage()
+{
+    NOT_IMPLEMENTED
+}
+
+QueueEntryInfoFetcher& ServerInterfaceMock::queueEntryInfoFetcher()
+{
+    NOT_IMPLEMENTED
+}
+
+DynamicModeController& ServerInterfaceMock::dynamicModeController()
+{
+    NOT_IMPLEMENTED
+}
+
+HistoryController& ServerInterfaceMock::historyController()
+{
+    NOT_IMPLEMENTED
+}
+
+CollectionWatcher& ServerInterfaceMock::collectionWatcher()
+{
+    if (_collectionWatcher) return *_collectionWatcher;
+
+    Q_UNREACHABLE();
+}
+
+UserDataFetcher& ServerInterfaceMock::userDataFetcher()
+{
+    if (_userDataFetcher) return *_userDataFetcher;
+
+    Q_UNREACHABLE();
+}
+
+bool ServerInterfaceMock::isLoggedIn() const
+{
+    return true;
+}
+
+quint32 ServerInterfaceMock::userLoggedInId() const
+{
+    return 1;
+}
+
+QString ServerInterfaceMock::userLoggedInName() const
+{
+    return "Username";
+}
+
+QTEST_MAIN(TestSortedCollectionTableModel)

--- a/testing/test_sortedcollectiontablemodel.cpp
+++ b/testing/test_sortedcollectiontablemodel.cpp
@@ -43,6 +43,9 @@ namespace
             [output](const QModelIndex& sourceParent, int sourceStart, int sourceEnd,
                      const QModelIndex& destinationParent, int destinationRow)
             {
+                Q_UNUSED(sourceParent)
+                Q_UNUSED(destinationParent)
+
                 QString s = "M";
                 s += QString::number(sourceStart);
                 s += "-";
@@ -360,13 +363,17 @@ QDateTime PlayerControllerMock::delayedStartServerDeadline()
     NOT_IMPLEMENTED
 }
 
-SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::activateDelayedStart(qint64 delayMilliseconds)
+SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::activateDelayedStart(
+    qint64 delayMilliseconds)
 {
+    Q_UNUSED(delayMilliseconds)
     NOT_IMPLEMENTED
 }
 
-SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::activateDelayedStart(QDateTime startTime)
+SimpleFuture<ResultMessageErrorCode> PlayerControllerMock::activateDelayedStart(
+    QDateTime startTime)
 {
+    Q_UNUSED(startTime)
     NOT_IMPLEMENTED
 }
 
@@ -392,6 +399,7 @@ void PlayerControllerMock::skip()
 
 void PlayerControllerMock::setVolume(int volume)
 {
+    Q_UNUSED(volume)
     NOT_IMPLEMENTED
 }
 
@@ -454,6 +462,7 @@ qint64 CurrentTrackMonitorMock::currentTrackLengthMilliseconds() const
 
 void CurrentTrackMonitorMock::seekTo(qint64 positionInMilliseconds)
 {
+    Q_UNUSED(positionInMilliseconds)
     NOT_IMPLEMENTED
 }
 
@@ -461,6 +470,7 @@ void CurrentTrackMonitorMock::seekTo(qint64 positionInMilliseconds)
 
 bool QueueHashesMonitorMock::isPresentInQueue(PMP::Client::LocalHashId hashId) const
 {
+    Q_UNUSED(hashId)
     return false;
 }
 
@@ -490,12 +500,14 @@ void UserForStatisticsDisplayMock::setPublic()
 
 void UserDataFetcherMock::enableAutoFetchForUser(quint32 userId)
 {
-    //
+    Q_UNUSED(userId)
 }
 
 const UserDataFetcher::HashData* UserDataFetcherMock::getHashDataForUser(quint32 userId,
                                                                        LocalHashId hashId)
 {
+    Q_UNUSED(userId)
+    Q_UNUSED(hashId)
     NOT_IMPLEMENTED
 }
 
@@ -538,6 +550,7 @@ QHash<LocalHashId, CollectionTrackInfo> CollectionWatcherMock::getCollection()
 
 CollectionTrackInfo CollectionWatcherMock::getTrack(LocalHashId hashId)
 {
+    Q_UNUSED(hashId)
     NOT_IMPLEMENTED
 }
 

--- a/testing/test_sortedcollectiontablemodel.h
+++ b/testing/test_sortedcollectiontablemodel.h
@@ -1,0 +1,199 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_TESTSORTEDCOLLECTIONTABLEMODEL_H
+#define PMP_TESTSORTEDCOLLECTIONTABLEMODEL_H
+
+#include "client/collectionwatcher.h"
+#include "client/currenttrackmonitor.h"
+#include "client/playercontroller.h"
+#include "client/queuehashesmonitor.h"
+#include "client/serverinterface.h"
+#include "client/userdatafetcher.h"
+
+#include "gui-remote/userforstatisticsdisplay.h"
+
+#include <QObject>
+
+using namespace PMP;
+using namespace PMP::Client;
+
+class PlayerControllerMock : public PMP::Client::PlayerController
+{
+    Q_OBJECT
+public:
+    PlayerState playerState() const override;
+    TriBool delayedStartActive() const override;
+    TriBool isTrackPresent() const override;
+    quint32 currentQueueId() const override;
+    uint queueLength() const override;
+    bool canPlay() const override;
+    bool canPause() const override;
+    bool canSkip() const override;
+
+    PlayerMode playerMode() const override;
+    quint32 personalModeUserId() const override;
+    QString personalModeUserLogin() const override;
+
+    int volume() const override;
+
+    QDateTime delayedStartServerDeadline() override;
+    SimpleFuture<ResultMessageErrorCode> activateDelayedStart(
+        qint64 delayMilliseconds) override;
+    SimpleFuture<ResultMessageErrorCode> activateDelayedStart(
+        QDateTime startTime) override;
+    SimpleFuture<ResultMessageErrorCode> deactivateDelayedStart() override;
+
+public Q_SLOTS:
+    void play() override;
+    void pause() override;
+    void skip() override;
+
+    void setVolume(int volume) override;
+
+    void switchToPublicMode() override;
+    void switchToPersonalMode() override;
+};
+
+class CurrentTrackMonitorMock : public CurrentTrackMonitor
+{
+    Q_OBJECT
+public:
+    PlayerState playerState() const override;
+
+    TriBool isTrackPresent() const override;
+    quint32 currentQueueId() const override;
+    qint64 currentTrackProgressMilliseconds() const override;
+
+    LocalHashId currentTrackHash() const override;
+
+    QString currentTrackTitle() const override;
+    QString currentTrackArtist() const override;
+    QString currentTrackPossibleFilename() const override;
+    qint64 currentTrackLengthMilliseconds() const override;
+
+public Q_SLOTS:
+    void seekTo(qint64 positionInMilliseconds) override;
+};
+
+class QueueHashesMonitorMock : public QueueHashesMonitor
+{
+    Q_OBJECT
+public:
+    bool isPresentInQueue(LocalHashId hashId) const override;
+};
+
+class UserForStatisticsDisplayMock : public UserForStatisticsDisplay
+{
+    Q_OBJECT
+public:
+    Nullable<quint32> userId() const override;
+    Nullable<bool> isPersonal() const override;
+
+    void setPersonal() override;
+    void setPublic() override;
+};
+
+class UserDataFetcherMock : public UserDataFetcher
+{
+    Q_OBJECT
+public:
+    void enableAutoFetchForUser(quint32 userId) override;
+
+    HashData const* getHashDataForUser(quint32 userId,
+                                       PMP::Client::LocalHashId hashId) override;
+};
+
+class CollectionWatcherMock : public CollectionWatcher
+{
+    Q_OBJECT
+public:
+    void addTrack(CollectionTrackInfo track);
+    void modifyTrackTitle(LocalHashId id, QString title);
+
+    bool isAlbumArtistSupported() const override;
+
+    void enableCollectionDownloading() override;
+    bool downloadingInProgress() const override;
+
+    QHash<LocalHashId, CollectionTrackInfo> getCollection() override;
+    CollectionTrackInfo getTrack(LocalHashId hashId) override;
+
+private:
+    QHash<LocalHashId, CollectionTrackInfo> _collection;
+};
+
+class ServerInterfaceMock : public PMP::Client::ServerInterface
+{
+    Q_OBJECT
+public:
+    ServerInterfaceMock();
+
+    void setUserDataFetcher(UserDataFetcher* userDataFetcher);
+    void setPlayerController(PlayerController* playerController);
+    void setCollectionWatcher(CollectionWatcher* collectionWatcher);
+    void setCurrentTrackMonitor(CurrentTrackMonitor* currentTrackMonitor);
+
+    PMP::Client::LocalHashIdRepository* hashIdRepository() const override;
+
+    PMP::Client::AuthenticationController& authenticationController() override;
+
+    PMP::Client::GeneralController& generalController() override;
+
+    PMP::Client::PlayerController& playerController() override;
+    PMP::Client::CurrentTrackMonitor& currentTrackMonitor() override;
+
+    PMP::Client::QueueController& queueController() override;
+    PMP::Client::AbstractQueueMonitor& queueMonitor() override;
+    PMP::Client::QueueEntryInfoStorage& queueEntryInfoStorage() override;
+    PMP::Client::QueueEntryInfoFetcher& queueEntryInfoFetcher() override;
+
+    PMP::Client::DynamicModeController& dynamicModeController() override;
+
+    PMP::Client::HistoryController& historyController() override;
+
+    PMP::Client::CollectionWatcher& collectionWatcher() override;
+    PMP::Client::UserDataFetcher& userDataFetcher() override;
+
+    bool isLoggedIn() const override;
+    quint32 userLoggedInId() const override;
+    QString userLoggedInName() const override;
+
+    bool connected() const override { return true; }
+
+private:
+    LocalHashIdRepository* _localHashIdRepository;
+    UserDataFetcher* _userDataFetcher { nullptr };
+    PlayerController* _playerController { nullptr };
+    CollectionWatcher* _collectionWatcher { nullptr };
+    CurrentTrackMonitor* _currentTrackMonitor { nullptr };
+};
+
+class TestSortedCollectionTableModel : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void trackTitleUpdateCausesMoveUpward();
+    void trackTitleUpdateCausesNoMove_v1();
+    void trackTitleUpdateCausesNoMove_v2();
+    void trackTitleUpdateCausesMoveDownward();
+    void trackTitleUpdateCausesMoveToLastPosition();
+};
+
+#endif


### PR DESCRIPTION
In some scenarios, an update to track data like title or artist would
cause the client to crash. This only happened when the track would need
to be moved down in the music collection view by just one slot.

It turned out that the logic for applying track updates in the music
collection view was incorrect. Moving tracks down in the list was done
with an off-by-one index.

This PR fixes the logic and adds unit tests to verify that track
updates move updated items to the correct index.