### PR TITLE
CMD-Remote: add "history" command

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -106,7 +106,6 @@ IDEAS
  * server database backup and restore
  * detect track BPM automatically
  * command-line remote: add a command for seeking (going to a specific time in the current track)
- * command-line remote: add a command for printing recent player history
  * command-line remote: extend the "nowplaying" command to also print album
  * command-line remote: extend the "trackstats" command to accept queue IDs
  * command-line remote: extend the "qmove" command to accept "front" or "end" as destination

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,7 @@ set(PMP_CMD_REMOTE_SOURCES
     cmd-remote/commandlineclient.cpp
     cmd-remote/commandparser.cpp
     cmd-remote/console.cpp
+    cmd-remote/historycommands.cpp
     cmd-remote/miscellaneouscommands.cpp
     cmd-remote/playercommands.cpp
     cmd-remote/queuecommands.cpp
@@ -180,6 +181,7 @@ set(PMP_CMD_REMOTE_HEADERS
     cmd-remote/command.h
     cmd-remote/commandbase.h
     cmd-remote/commandlineclient.h
+    cmd-remote/historycommands.h
     cmd-remote/miscellaneouscommands.h
     cmd-remote/playercommands.h
     cmd-remote/queuecommands.h

--- a/src/cmd-remote/cmd-remote-main.cpp
+++ b/src/cmd-remote/cmd-remote-main.cpp
@@ -48,6 +48,7 @@ usage:
     volume <number>: set volume percentage (0-100)
     nowplaying: get info about the track currently playing
     queue: print queue length and the first tracks waiting in the queue
+    history: print recent playback history
     personalmode: switch to personal mode
     publicmode: switch to public mode
     dynamicmode on|off: enable/disable dynamic mode (auto queue fill)

--- a/src/cmd-remote/commandparser.cpp
+++ b/src/cmd-remote/commandparser.cpp
@@ -22,6 +22,7 @@
 #include "common/unicodechars.h"
 
 #include "administrativecommands.h"
+#include "historycommands.h"
 #include "miscellaneouscommands.h"
 #include "playercommands.h"
 #include "queuecommands.h"
@@ -324,6 +325,10 @@ namespace PMP
         else if (command == "queue")
         {
             handleCommandNotRequiringArguments<QueueCommand>(commandWithArgs);
+        }
+        else if (command == "history")
+        {
+            handleCommandNotRequiringArguments<HistoryCommand>(commandWithArgs);
         }
         else if (command == "personalmode")
         {

--- a/src/cmd-remote/historycommands.cpp
+++ b/src/cmd-remote/historycommands.cpp
@@ -1,0 +1,155 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "historycommands.h"
+
+#include "common/util.h"
+
+#include "client/historycontroller.h"
+#include "client/queueentryinfostorage.h"
+#include "client/serverinterface.h"
+
+using namespace PMP::Client;
+
+namespace PMP
+{
+    /* ===== HistoryCommand ===== */
+
+    bool HistoryCommand::requiresAuthentication() const
+    {
+        return true;
+    }
+
+    void HistoryCommand::run(Client::ServerInterface* serverInterface)
+    {
+        auto* historyController = &serverInterface->historyController();
+        auto* queueEntryInfoStorage = &serverInterface->queueEntryInfoStorage();
+
+        connect(
+            historyController, &HistoryController::receivedPlayerHistory,
+            this,
+            [this, queueEntryInfoStorage](QVector<PMP::PlayerHistoryTrackInfo> tracks)
+            {
+                _tracks = tracks;
+                _listReceived = true;
+
+                for (auto& track : _tracks)
+                {
+                    queueEntryInfoStorage->fetchEntry(track.queueID());
+                }
+
+                listenerSlot();
+            }
+        );
+        connect(
+            queueEntryInfoStorage, &QueueEntryInfoStorage::tracksChanged,
+            this, &HistoryCommand::listenerSlot
+        );
+
+        addStep(
+            [this, queueEntryInfoStorage]() -> StepResult
+            {
+                if (!_listReceived)
+                    return StepResult::stepIncomplete();
+
+                bool needToWaitForFilename = false;
+                for (auto& track : _tracks)
+                {
+                    auto queueId = track.queueID();
+
+                    auto entry = queueEntryInfoStorage->entryInfoByQueueId(queueId);
+                    if (!entry || entry->type() == QueueEntryType::Unknown)
+                        return StepResult::stepIncomplete(); /* info not available yet */
+
+                    if (entry->needFilename())
+                        needToWaitForFilename = true;
+                }
+
+                if (needToWaitForFilename)
+                    setStepDelay(50);
+
+                return StepResult::stepCompleted();
+            }
+        );
+        addStep(
+            [this, queueEntryInfoStorage]() -> StepResult
+            {
+                return printHistory(queueEntryInfoStorage);
+            }
+        );
+
+        historyController->sendPlayerHistoryRequest(_fetchLimit);
+    }
+
+    CommandBase::StepResult HistoryCommand::printHistory(
+        QueueEntryInfoStorage* queueEntryInfoStorage)
+    {
+        QString output;
+        output.reserve(80 + 80 + 80 * _fetchLimit);
+
+        output += "       Ended       |  QID  | Length |"
+                  " Title                          | Artist";
+
+        for (int index = 0; index < _tracks.size(); ++index)
+        {
+            output += "\n";
+            auto const& entry = _tracks[index];
+
+            auto endedAt = entry.ended().toLocalTime();
+            output += endedAt.toString("yyyy-MM-dd HH:mm:ss");
+            output += "|";
+
+            auto queueId = entry.queueID();
+            output += QString::number(queueId).rightJustified(7);
+            output += "|";
+
+            auto* info = queueEntryInfoStorage->entryInfoByQueueId(entry.queueID());
+
+            auto lengthMilliseconds = info ? info->lengthInMilliseconds() : -1;
+            if (lengthMilliseconds >= 0)
+            {
+                auto lengthString =
+                    Util::millisecondsToShortDisplayTimeText(lengthMilliseconds);
+                output += lengthString.rightJustified(8);
+            }
+            else
+            {
+                output += "   ??   ";
+            }
+            output += "|";
+
+            if (info == nullptr)
+            {
+                output += " ??";
+            }
+            else if (info->needFilename() && !info->informativeFilename().isEmpty())
+            {
+                output += info->informativeFilename();
+            }
+            else
+            {
+                output += info->title().leftJustified(32);
+                output += "|";
+                output += info->artist();
+            }
+        }
+
+        return StepResult::commandSuccessful(output);
+    }
+}

--- a/src/cmd-remote/historycommands.h
+++ b/src/cmd-remote/historycommands.h
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_HISTORYCOMMANDS_H
+#define PMP_HISTORYCOMMANDS_H
+
+#include "commandbase.h"
+
+#include "common/playerhistorytrackinfo.h"
+
+#include <QVector>
+
+namespace PMP::Client
+{
+    class QueueEntryInfoStorage;
+}
+
+namespace PMP
+{
+    class HistoryCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
+
+    private:
+        StepResult printHistory(Client::QueueEntryInfoStorage* queueEntryInfoStorage);
+
+        static const int _fetchLimit { 10 };
+
+        QVector<PMP::PlayerHistoryTrackInfo> _tracks;
+        bool _listReceived { false };
+    };
+}
+#endif

--- a/src/cmd-remote/queuecommands.h
+++ b/src/cmd-remote/queuecommands.h
@@ -50,7 +50,7 @@ namespace PMP
                               Client::QueueEntryInfoStorage* queueEntryInfoStorage);
         QString getSpecialEntryText(Client::QueueEntryInfo const* entry) const;
 
-        int _fetchLimit { 10 };
+        static const int _fetchLimit { 10 };
     };
 
     class BreakCommand : public CommandBase


### PR DESCRIPTION
This command prints recent player history, similar to the history view in the desktop client.