### PR TITLE
Track info dialog: add "history" tab

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -95,7 +95,6 @@ IDEAS
  * track info dialog: display filename(s)
  * track info dialog: should become modeless
  * track info dialog: last heard: display "almost 3 months" ago instead of "2 months ago" when applicable
- **** track info dialog: show personal play history for that track
  * provide list of all artists/albums in the collection
  * guest account for party guests; probably without personal mode
  * giant "now playing" screen banner

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2011-2023, Kevin Andre <hyperquantum@gmail.com>
+# Copyright (C) 2011-2024, Kevin Andre <hyperquantum@gmail.com>
 #
 # This file is part of PMP (Party Music Player).
 #
@@ -200,6 +200,7 @@ set(PMP_GUI_REMOTE_SOURCES
     gui-remote/delayedstartnotification.cpp
     gui-remote/dynamicmodeparametersdialog.cpp
     gui-remote/gui-remote-metatypes.cpp
+    gui-remote/historymodel.cpp
     gui-remote/loginwidget.cpp
     gui-remote/mainwidget.cpp
     gui-remote/mainwindow.cpp
@@ -229,6 +230,7 @@ set(PMP_GUI_REMOTE_HEADERS
     gui-remote/delayedstartdialog.h
     gui-remote/delayedstartnotification.h
     gui-remote/dynamicmodeparametersdialog.h
+    gui-remote/historymodel.h
     gui-remote/loginwidget.h
     gui-remote/mainwidget.h
     gui-remote/mainwindow.h

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -1405,6 +1405,10 @@ namespace PMP::Client
 
         if (!_serverCapabilities->supportsRequestingPersonalTrackHistory())
             return serverTooOldFutureError();
+
+        qDebug() << "ServerConnection: sending request for track history;"
+                 << "hash ID:" << hashId << " user ID:" << userId << " limit:" << limit
+                 << "start ID:" << startId;
 
         auto hash = _hashIdRepository->getHash(hashId);
         limit = qBound(0, limit, 255);

--- a/src/common/playerhistorytrackinfo.h
+++ b/src/common/playerhistorytrackinfo.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2017-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -50,6 +50,8 @@ namespace PMP
         bool hadError() const { return _error; }
         bool hadSeek() const { return _seek; }
         int permillage() const { return _permillage; }
+
+        bool validForScoring() const { return !hadError() && !hadSeek(); }
 
     private:
         uint _queueID;

--- a/src/gui-remote/historymodel.cpp
+++ b/src/gui-remote/historymodel.cpp
@@ -1,0 +1,240 @@
+/*
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "historymodel.h"
+
+#include "client/historycontroller.h"
+#include "client/serverinterface.h"
+
+#include <QtDebug>
+
+#include <algorithm>
+
+using namespace PMP::Client;
+
+namespace PMP
+{
+    HistoryModel::HistoryModel(QObject* parent, uint userId, LocalHashId hashId,
+                               ServerInterface* serverInterface)
+     : QAbstractTableModel(parent),
+       _serverInterface(serverInterface),
+       _userId(userId),
+       _hashId(hashId)
+    {
+        qDebug() << "HistoryModel: created with user ID" << userId
+                 << "and hash ID" << hashId;
+
+        connect(_serverInterface, &ServerInterface::connectedChanged,
+                this, &HistoryModel::onConnectedChanged);
+
+        onConnectedChanged();
+    }
+
+    uint PMP::HistoryModel::userId() const
+    {
+        return _userId;
+    }
+
+    void HistoryModel::setUserId(uint userId)
+    {
+        if (_userId == userId)
+            return;
+
+        qDebug() << "HistoryModel: user ID changing from" << _userId << "to" << userId;
+
+        _stateAtLastRequest++;
+        _userId = userId;
+
+        reload();
+    }
+
+    LocalHashId HistoryModel::track() const
+    {
+        return _hashId;
+    }
+
+    void HistoryModel::setTrack(Client::LocalHashId hashId)
+    {
+        if (_hashId == hashId)
+            return;
+
+        qDebug() << "HistoryModel: track ID changing from" << _hashId << "to" << hashId;
+
+        _stateAtLastRequest++;
+        _hashId = hashId;
+
+        reload();
+    }
+
+    int HistoryModel::rowCount(const QModelIndex& parent) const
+    {
+        Q_UNUSED(parent)
+
+        return _entries.size();
+    }
+
+    int HistoryModel::columnCount(const QModelIndex& parent) const
+    {
+        Q_UNUSED(parent)
+
+        return 2;
+    }
+
+    QVariant HistoryModel::headerData(int section, Qt::Orientation orientation,
+                                      int role) const
+    {
+        if (role == Qt::DisplayRole && orientation == Qt::Horizontal)
+        {
+            switch (section)
+            {
+            case 0: return QString(tr("Started"));
+            case 1: return QString(tr("Ended"));
+            }
+        }
+
+        return {};
+    }
+
+    QVariant HistoryModel::data(const QModelIndex& index, int role) const
+    {
+        if (!index.isValid() || index.row() < 0 || index.row() >= _entries.size())
+            return {};
+
+        auto& entry = _entries[index.row()];
+
+        if (role == Qt::DisplayRole)
+        {
+            int col = index.column();
+
+            switch (col)
+            {
+                case 0:
+                {
+                    auto started = entry.started()/*.addMSecs(_clientClockTimeOffsetMs)*/;
+                    return started.toLocalTime();
+                }
+                case 1:
+                {
+                    auto ended = entry.ended()/*.addMSecs(_clientClockTimeOffsetMs)*/;
+                    return ended.toLocalTime();
+                }
+            }
+        }
+
+        return {};
+    }
+
+    Qt::ItemFlags HistoryModel::flags(const QModelIndex& index) const
+    {
+        Q_UNUSED(index);
+
+        Qt::ItemFlags f(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
+        return f;
+    }
+
+    void HistoryModel::reload()
+    {
+        if (!_entries.isEmpty())
+        {
+            beginRemoveRows({}, 0, _entries.size() - 1);
+            _entries.clear();
+            endRemoveRows();
+        }
+
+        if (_serverInterface->connected())
+            sendInitialRequest();
+    }
+
+    void HistoryModel::sendInitialRequest()
+    {
+        auto& historyController = _serverInterface->historyController();
+
+        auto state = _stateAtLastRequest;
+        auto future =
+            historyController.getPersonalTrackHistory(_hashId, _userId,
+                                                      _fragmentSizeLimit);
+
+        future.addResultListener(
+            this,
+            [this, state](HistoryFragment fragment)
+            {
+                handleHistoryRequestResult(fragment, state);
+            }
+        );
+        //future.addFailureListener(this, [this](AnyResultMessageCode code) {});
+    }
+
+    void HistoryModel::onConnectedChanged()
+    {
+        bool isConnected = _serverInterface->connected();
+
+        if (isConnected)
+        {
+            reload();
+        }
+        else
+        {
+            //
+        }
+    }
+
+    void HistoryModel::handleHistoryRequestResult(Client::HistoryFragment fragment,
+                                                  uint stateExpected)
+    {
+        if (stateExpected != _stateAtLastRequest)
+        {
+            return;
+        }
+
+        auto entries = fragment.entries();
+        if (entries.isEmpty())
+        {
+            return; /* we got everything */
+        }
+
+        /* make sure we have the entries ordered descending, so most recent first */
+        if (entries.size() >= 2 && entries.first().started() < entries.last().started())
+        {
+            std::reverse(entries.begin(), entries.end());
+        }
+
+        auto existingRowsCount = _entries.size();
+
+        beginInsertRows({}, existingRowsCount, existingRowsCount + entries.size() - 1);
+        _entries.append(entries);
+        endInsertRows();
+
+        auto& historyController = _serverInterface->historyController();
+
+        auto state = _stateAtLastRequest;
+        auto future =
+            historyController.getPersonalTrackHistory(_hashId, _userId,
+                                                      _fragmentSizeLimit,
+                                                      fragment.nextStartId());
+
+        future.addResultListener(
+            this,
+            [this, state](HistoryFragment fragment)
+            {
+                handleHistoryRequestResult(fragment, state);
+            }
+        );
+        //future.addFailureListener(this, [this](AnyResultMessageCode code) {});
+    }
+}

--- a/src/gui-remote/historymodel.cpp
+++ b/src/gui-remote/historymodel.cpp
@@ -93,7 +93,7 @@ namespace PMP
     {
         Q_UNUSED(parent)
 
-        return 2;
+        return 3;
     }
 
     QVariant HistoryModel::headerData(int section, Qt::Orientation orientation,
@@ -105,6 +105,7 @@ namespace PMP
             {
             case 0: return QString(tr("Started"));
             case 1: return QString(tr("Ended"));
+            case 2: return QString(tr("Affects score"));
             }
         }
 
@@ -134,6 +135,10 @@ namespace PMP
                     auto ended = entry.ended()/*.addMSecs(_clientClockTimeOffsetMs)*/;
                     return ended.toLocalTime();
                 }
+                case 2:
+                    return entry.validForScoring()
+                               ? QString(tr("Yes"))
+                               : QString(tr("No"));
             }
         }
 

--- a/src/gui-remote/historymodel.cpp
+++ b/src/gui-remote/historymodel.cpp
@@ -160,6 +160,10 @@ namespace PMP
             beginRemoveRows({}, 0, _entries.size() - 1);
             _entries.clear();
             endRemoveRows();
+
+            _countTotal = 0;
+            _countForScore = 0;
+            Q_EMIT countsChanged();
         }
 
         if (_serverInterface->connected())
@@ -225,6 +229,8 @@ namespace PMP
         _entries.append(entries);
         endInsertRows();
 
+        addCounts(entries);
+
         auto& historyController = _serverInterface->historyController();
 
         auto state = _stateAtLastRequest;
@@ -241,5 +247,19 @@ namespace PMP
             }
         );
         //future.addFailureListener(this, [this](AnyResultMessageCode code) {});
+    }
+
+    void HistoryModel::addCounts(const QVector<Client::HistoryEntry>& entries)
+    {
+        auto extraCountTotal = entries.size();
+        auto extraCountForScore =
+            std::count_if(
+                entries.begin(), entries.end(),
+                [](HistoryEntry const& entry) { return entry.validForScoring(); }
+            );
+
+        _countTotal += extraCountTotal;
+        _countForScore += extraCountForScore;
+        Q_EMIT countsChanged();
     }
 }

--- a/src/gui-remote/historymodel.h
+++ b/src/gui-remote/historymodel.h
@@ -20,11 +20,15 @@
 #ifndef PMP_HISTORYMODEL_H
 #define PMP_HISTORYMODEL_H
 
+#include "common/playerhistorytrackinfo.h"
+
 #include "client/historyentry.h"
 #include "client/localhashid.h"
 
 #include <QAbstractTableModel>
 #include <QVector>
+
+#include <deque>
 
 namespace PMP::Client
 {
@@ -64,9 +68,11 @@ namespace PMP
         void reload();
         void sendInitialRequest();
         void onConnectedChanged();
+        void handleNewPlayerHistoryEntry(PMP::PlayerHistoryTrackInfo track);
         void handleHistoryRequestResult(Client::HistoryFragment fragment,
                                         uint stateExpected);
-        void addCounts(QVector<Client::HistoryEntry> const& entries);
+        void addToCounts(Client::HistoryEntry const& entry);
+        void addToCounts(QVector<Client::HistoryEntry> const& entries);
 
         static const int _fragmentSizeLimit = 20;
 
@@ -74,7 +80,7 @@ namespace PMP
         uint _stateAtLastRequest { 0 };
         uint _userId;
         Client::LocalHashId _hashId;
-        QVector<Client::HistoryEntry> _entries;
+        std::deque<Client::HistoryEntry> _entries;
         int _countTotal { 0 };
         int _countForScore { 0 };
     };

--- a/src/gui-remote/historymodel.h
+++ b/src/gui-remote/historymodel.h
@@ -47,6 +47,9 @@ namespace PMP
         Client::LocalHashId track() const;
         void setTrack(Client::LocalHashId hashId);
 
+        int countTotal() const { return _countTotal; }
+        int countForScore() const { return _countForScore; }
+
         int rowCount(const QModelIndex& parent = QModelIndex()) const override;
         int columnCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant headerData(int section, Qt::Orientation orientation,
@@ -54,12 +57,16 @@ namespace PMP
         QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
         Qt::ItemFlags flags(const QModelIndex& index) const override;
 
+    Q_SIGNALS:
+        void countsChanged();
+
     private:
         void reload();
         void sendInitialRequest();
         void onConnectedChanged();
         void handleHistoryRequestResult(Client::HistoryFragment fragment,
                                         uint stateExpected);
+        void addCounts(QVector<Client::HistoryEntry> const& entries);
 
         static const int _fragmentSizeLimit = 20;
 
@@ -68,6 +75,8 @@ namespace PMP
         uint _userId;
         Client::LocalHashId _hashId;
         QVector<Client::HistoryEntry> _entries;
+        int _countTotal { 0 };
+        int _countForScore { 0 };
     };
 }
 #endif

--- a/src/gui-remote/historymodel.h
+++ b/src/gui-remote/historymodel.h
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_HISTORYMODEL_H
+#define PMP_HISTORYMODEL_H
+
+#include "client/historyentry.h"
+#include "client/localhashid.h"
+
+#include <QAbstractTableModel>
+#include <QVector>
+
+namespace PMP::Client
+{
+    class HistoryController;
+    class ServerInterface;
+}
+
+namespace PMP
+{
+    class HistoryModel : public QAbstractTableModel
+    {
+        Q_OBJECT
+    public:
+        HistoryModel(QObject* parent, uint userId, Client::LocalHashId hashId,
+                     Client::ServerInterface* serverInterface);
+
+        uint userId() const;
+        void setUserId(uint userId);
+
+        Client::LocalHashId track() const;
+        void setTrack(Client::LocalHashId hashId);
+
+        int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+        int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+        QVariant headerData(int section, Qt::Orientation orientation,
+                            int role = Qt::DisplayRole) const override;
+        QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+        Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+    private:
+        void reload();
+        void sendInitialRequest();
+        void onConnectedChanged();
+        void handleHistoryRequestResult(Client::HistoryFragment fragment,
+                                        uint stateExpected);
+
+        static const int _fragmentSizeLimit = 20;
+
+        Client::ServerInterface* _serverInterface;
+        uint _stateAtLastRequest { 0 };
+        uint _userId;
+        Client::LocalHashId _hashId;
+        QVector<Client::HistoryEntry> _entries;
+    };
+}
+#endif

--- a/src/gui-remote/playerhistorymodel.h
+++ b/src/gui-remote/playerhistorymodel.h
@@ -46,15 +46,16 @@ namespace PMP
 
         Client::LocalHashId trackHashAt(int rowIndex) const;
 
-        int rowCount(const QModelIndex& parent = QModelIndex()) const;
-        int columnCount(const QModelIndex& parent = QModelIndex()) const;
+        int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+        int columnCount(const QModelIndex& parent = QModelIndex()) const override;
         QVariant headerData(int section, Qt::Orientation orientation,
-                            int role = Qt::DisplayRole) const;
-        QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const;
-        Qt::ItemFlags flags(const QModelIndex& index) const;
-        Qt::DropActions supportedDragActions() const;
-        Qt::DropActions supportedDropActions() const;
-        QMimeData* mimeData(const QModelIndexList& indexes) const;
+                            int role = Qt::DisplayRole) const override;
+        QVariant data(const QModelIndex& index,
+                      int role = Qt::DisplayRole) const override;
+        Qt::ItemFlags flags(const QModelIndex& index) const override;
+        Qt::DropActions supportedDragActions() const override;
+        Qt::DropActions supportedDropActions() const override;
+        QMimeData* mimeData(const QModelIndexList& indexes) const override;
 
     private Q_SLOTS:
         void onReceivedPlayerHistoryEntry(PMP::PlayerHistoryTrackInfo track);

--- a/src/gui-remote/trackinfodialog.cpp
+++ b/src/gui-remote/trackinfodialog.cpp
@@ -163,6 +163,19 @@ namespace PMP
         _ui->historyTableView->setModel(_historyModel);
 
         connect(
+            _historyModel, &HistoryModel::countsChanged,
+            this,
+            [this]()
+            {
+                auto countTotal = _historyModel->countTotal();
+                auto countForScore = _historyModel->countForScore();
+
+                _ui->countTotalValueLabel->setText(QString::number(countTotal));
+                _ui->countForScoreValueLabel->setText(QString::number(countForScore));
+            }
+        );
+
+        connect(
             _ui->userComboBox, qOverload<int>(&QComboBox::currentIndexChanged),
             this,
             [this]()

--- a/src/gui-remote/trackinfodialog.cpp
+++ b/src/gui-remote/trackinfodialog.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -31,6 +31,7 @@
 #include "client/serverinterface.h"
 #include "client/userdatafetcher.h"
 
+#include "historymodel.h"
 #include "userforstatisticsdisplay.h"
 
 #include <QApplication>
@@ -154,7 +155,12 @@ namespace PMP
 
     void TrackInfoDialog::init()
     {
+        _userId = _userStatisticsDisplay->userId().valueOr(0);
+
         _ui->setupUi(this);
+
+        _historyModel = new HistoryModel(this, _userId, _trackHashId, _serverInterface);
+        _ui->historyTableView->setModel(_historyModel);
 
         connect(
             _ui->userComboBox, qOverload<int>(&QComboBox::currentIndexChanged),
@@ -166,6 +172,9 @@ namespace PMP
 
                 auto userId = _ui->userComboBox->currentData().value<int>();
                 _userId = userId;
+                _ui->usernameValueLabel->setText(_ui->userComboBox->currentText());
+
+                _historyModel->setUserId(_userId);
 
                 fillUserData(_trackHashId, _userId);
             }
@@ -179,8 +188,6 @@ namespace PMP
             layout->removeWidget(_ui->albumArtistLabel);
             layout->removeWidget(_ui->albumArtistValueLabel);
         }
-
-        _userId = _userStatisticsDisplay->userId().valueOr(0);
 
         _serverInterface->authenticationController()
             .getUserAccounts()
@@ -268,23 +275,35 @@ namespace PMP
 
         auto* combo = _ui->userComboBox;
         combo->clear();
+        _ui->usernameValueLabel->clear();
 
         int indexToSelect = -1;
 
         combo->addItem(tr("Public"), QVariant::fromValue(int(0)));
-        if (_userId == 0) { indexToSelect = 0; }
+        if (_userId == 0)
+        {
+            indexToSelect = 0;
+            _ui->usernameValueLabel->setText(tr("Public"));
+        }
 
         auto myUserId = _serverInterface->authenticationController().userLoggedInId();
         auto myUsername = _serverInterface->authenticationController().userLoggedInName();
         combo->addItem(myUsername, QVariant::fromValue(myUserId));
-        if (_userId == myUserId) { indexToSelect = 1; }
+        if (_userId == myUserId)
+        {
+            indexToSelect = 1;
+            _ui->usernameValueLabel->setText(myUsername);
+        }
 
         for (auto const& account : accounts)
         {
             if (account.userId == myUserId) continue; /* already added before the loop */
 
             if (account.userId == _userId && indexToSelect < 0)
+            {
                 indexToSelect = combo->count();
+                _ui->usernameValueLabel->setText(account.username);
+            }
 
             combo->addItem(account.username, QVariant::fromValue(account.userId));
         }
@@ -318,6 +337,8 @@ namespace PMP
     {
         auto hash = _serverInterface->hashIdRepository()->getHash(_trackHashId);
         _ui->hashValueLabel->setText(hash.toFancyString());
+
+        _historyModel->setTrack(_trackHashId);
     }
 
     void TrackInfoDialog::fillTrackDetails(const CollectionTrackInfo& trackInfo)
@@ -390,6 +411,7 @@ namespace PMP
         }
 
         _ui->scoreValueLabel->setText(scoreText);
+        _ui->scoreValueLabel2->setText(scoreText);
     }
 
     void TrackInfoDialog::clearTrackDetails()

--- a/src/gui-remote/trackinfodialog.h
+++ b/src/gui-remote/trackinfodialog.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -40,6 +40,7 @@ namespace PMP::Client
 
 namespace PMP
 {
+    class HistoryModel;
     class UserForStatisticsDisplay;
 
     class TrackInfoDialog : public QDialog
@@ -78,6 +79,7 @@ namespace PMP
         void clearUserData();
 
         Ui::TrackInfoDialog* _ui;
+        HistoryModel* _historyModel { nullptr };
         Client::ServerInterface* _serverInterface;
         UserForStatisticsDisplay* _userStatisticsDisplay;
         QTimer* _lastHeardUpdateTimer;

--- a/src/gui-remote/trackinfodialog.ui
+++ b/src/gui-remote/trackinfodialog.ui
@@ -251,7 +251,20 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <layout class="QFormLayout" name="formLayout_3">
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="0" column="5">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="usernameLabel2">
            <property name="styleSheet">
@@ -259,6 +272,51 @@
            </property>
            <property name="text">
             <string>Username:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="scoreValueLabel2">
+           <property name="text">
+            <string>(score)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="4">
+          <widget class="QLabel" name="countTotalValueLabel">
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QLabel" name="countForScoreLabel">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Count for score:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="4">
+          <widget class="QLabel" name="countForScoreValueLabel">
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QLabel" name="countTotalLabel">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Count total:</string>
            </property>
           </widget>
          </item>
@@ -279,12 +337,18 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="scoreValueLabel2">
-           <property name="text">
-            <string>(score)</string>
+         <item row="0" column="2">
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
-          </widget>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>

--- a/src/gui-remote/trackinfodialog.ui
+++ b/src/gui-remote/trackinfodialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>638</width>
-    <height>419</height>
+    <width>646</width>
+    <height>495</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,222 +15,284 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="trackMetadataGroupBox">
-     <property name="title">
-      <string>Track metadata</string>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <layout class="QFormLayout" name="formLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="titleLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Title:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="titleValueLabel">
-        <property name="text">
-         <string>(title)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="artistLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Artist:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="artistValueLabel">
-        <property name="text">
-         <string>(artist)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="albumLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Album:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="albumValueLabel">
-        <property name="text">
-         <string>(album)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="lengthLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Length:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="lengthValueLabel">
-        <property name="text">
-         <string>(length)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="albumArtistLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Album artist:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="albumArtistValueLabel">
-        <property name="text">
-         <string>(album artist)</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="personalStatisticsGroupBox">
-     <property name="title">
-      <string>Personal statistics</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="usernameLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Username:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lastHeardLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Last heard:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="lastHeardValueLabel">
-        <property name="text">
-         <string>(last heard)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="scoreLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Score:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLabel" name="scoreValueLabel">
-        <property name="text">
-         <string>(score)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="userComboBox"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="technicalInfoGroupBox">
-     <property name="title">
-      <string>Technical information</string>
-     </property>
-     <layout class="QFormLayout" name="fileInfoFormLayout">
-      <item row="1" column="0">
-       <widget class="QLabel" name="hashLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Hash:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="hashValueLabel">
-        <property name="text">
-         <string>1234567-2fd4e1c67a2d28fced849ee1bb76e7391b93eb12-9e107d9d372bb6826bd81d3542a419d6</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="queueIdLabel">
-        <property name="styleSheet">
-         <string notr="true">font-weight: bold</string>
-        </property>
-        <property name="text">
-         <string>Queue ID:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="queueIdValueLabel">
-        <property name="text">
-         <string>1234</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <widget class="QWidget" name="overviewTab">
+      <attribute name="title">
+       <string>Overview</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="trackMetadataGroupBox">
+         <property name="title">
+          <string>Track metadata</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="titleLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Title:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="titleValueLabel">
+            <property name="text">
+             <string>(title)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="artistLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Artist:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="artistValueLabel">
+            <property name="text">
+             <string>(artist)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="albumLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Album:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="albumValueLabel">
+            <property name="text">
+             <string>(album)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="albumArtistLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Album artist:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="albumArtistValueLabel">
+            <property name="text">
+             <string>(album artist)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="lengthLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Length:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLabel" name="lengthValueLabel">
+            <property name="text">
+             <string>(length)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>128</width>
+           <height>14</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="personalStatisticsGroupBox">
+         <property name="title">
+          <string>Personal statistics</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="usernameLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Username:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lastHeardLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Last heard:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="lastHeardValueLabel">
+            <property name="text">
+             <string>(last heard)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="scoreLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Score:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="scoreValueLabel">
+            <property name="text">
+             <string>(score)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="userComboBox"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>228</width>
+           <height>14</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="technicalInfoGroupBox">
+         <property name="title">
+          <string>Technical information</string>
+         </property>
+         <layout class="QFormLayout" name="fileInfoFormLayout">
+          <item row="1" column="0">
+           <widget class="QLabel" name="hashLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Hash:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="hashValueLabel">
+            <property name="text">
+             <string>1234567-2fd4e1c67a2d28fced849ee1bb76e7391b93eb12-9e107d9d372bb6826bd81d3542a419d6</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="queueIdLabel">
+            <property name="styleSheet">
+             <string notr="true">font-weight: bold</string>
+            </property>
+            <property name="text">
+             <string>Queue ID:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="queueIdValueLabel">
+            <property name="text">
+             <string>1234</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="historyTab">
+      <attribute name="title">
+       <string>History</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QFormLayout" name="formLayout_3">
+         <item row="0" column="0">
+          <widget class="QLabel" name="usernameLabel2">
+           <property name="styleSheet">
+            <string notr="true">font-weight: bold</string>
+           </property>
+           <property name="text">
+            <string>Username:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="usernameValueLabel">
+           <property name="text">
+            <string>(username)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="scoreLabel2">
+           <property name="styleSheet">
+            <string notr="true">font-weight: bold</string>
+           </property>
+           <property name="text">
+            <string>Score:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLabel" name="scoreValueLabel2">
+           <property name="text">
+            <string>(score)</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QTableView" name="historyTableView"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/server/history.cpp
+++ b/src/server/history.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -120,11 +120,10 @@ namespace PMP::Server
                 [statistics, entry](uint hashId)
                 {
                     uint userId = entry->user();
-                    bool validForScoring = !(entry->hadError() || entry->hadSeek());
 
                     return statistics->addToHistory(userId, hashId, entry->started(),
                                                     entry->ended(), entry->permillage(),
-                                                    validForScoring);
+                                                    entry->validForScoring());
                 },
                 failureIdentityFunction
             );

--- a/src/server/recenthistoryentry.h
+++ b/src/server/recenthistoryentry.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -47,6 +47,8 @@ namespace PMP::Server
         bool hadError() const { return _error; }
         bool hadSeek() const { return _seek; }
         int permillage() const { return _permillage; }
+
+        bool validForScoring() const { return !hadError() && !hadSeek(); }
 
     private:
         uint _queueId;


### PR DESCRIPTION
Introduce a tab widget to the track history dialog. Put the existing information (title, last heard, hash...) on the first tab page. Add a second tab page, "history", with the complete playback history of the track for the user that is selected on the first tab.

_Note_: the history can be incomplete when multiple hashes have historically been used for the same track. This will be fixed later, on the server side.