### PR TITLE
Take hash equivalences into account when loading the history of a track

### DIFF
--- a/src/server/database.h
+++ b/src/server/database.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -113,8 +113,8 @@ namespace PMP::Server
                                                             int limit);
         ResultOrError<QVector<DatabaseRecords::HistoryRecord>, FailureType>
                                                                    getTrackHistoryForUser(
-                                                                quint32 hashId,
                                                                 quint32 userId,
+                                                                QVector<quint32> hashIds,
                                                                 uint startId,
                                                                 int limit);
 

--- a/src/server/server-main.cpp
+++ b/src/server/server-main.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2011-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2011-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -315,7 +315,8 @@ static int runServer(QCoreApplication& app, bool doIndexation)
 
     TcpServer server(nullptr, &serverSettings, serverInstanceIdentifier);
     bool listening =
-        server.listen(&player, &generator, &history, &hashIdRegistrar, &users,
+        server.listen(&player, &generator, &history, &hashIdRegistrar, &hashRelations,
+                      &users,
                       &collectionMonitor, &serverHealthMonitor, &scrobbling,
                       &delayedStart,
                       QHostAddress::Any, 23432);

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -47,6 +47,7 @@ namespace PMP::Server
     class DelayedStart;
     class Generator;
     class HashIdRegistrar;
+    class HashRelations;
     class History;
     class Player;
     class PlayerQueue;
@@ -72,7 +73,9 @@ namespace PMP::Server
     public:
         ServerInterface(ServerSettings* serverSettings, TcpServer* server, Player* player,
                         Generator* generator, History* history,
-                        HashIdRegistrar* hashIdRegistrar, Users* users,
+                        HashIdRegistrar* hashIdRegistrar,
+                        HashRelations* hashRelations,
+                        Users* users,
                         DelayedStart* delayedStart, Scrobbling* scrobbling);
 
         ~ServerInterface();
@@ -196,6 +199,7 @@ namespace PMP::Server
         Generator* _generator;
         History* _history;
         HashIdRegistrar* _hashIdRegistrar;
+        HashRelations* _hashRelations;
         Users* _users;
         DelayedStart* _delayedStart;
         Scrobbling* _scrobbling;

--- a/src/server/tcpserver.cpp
+++ b/src/server/tcpserver.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -43,14 +43,6 @@ namespace PMP::Server
      : QObject(parent),
        _uuid(serverInstanceIdentifier),
        _settings(serverSettings),
-       _player(nullptr),
-       _generator(nullptr),
-       _history(nullptr),
-       _users(nullptr),
-       _collectionMonitor(nullptr),
-       _serverHealthMonitor(nullptr),
-       _scrobbling(nullptr),
-       _delayedStart(nullptr),
        _server(new QTcpServer(this)),
        _udpSocket(new QUdpSocket(this)),
        _broadcastTimer(new QTimer(this)),
@@ -124,6 +116,7 @@ namespace PMP::Server
 
     bool TcpServer::listen(Player* player, Generator* generator, History* history,
                         HashIdRegistrar* hashIdRegistrar,
+                        HashRelations* hashRelations,
                         Users* users,
                         CollectionMonitor* collectionMonitor,
                         ServerHealthMonitor* serverHealthMonitor,
@@ -135,6 +128,7 @@ namespace PMP::Server
         _generator = generator;
         _history = history;
         _hashIdRegistrar = hashIdRegistrar;
+        _hashRelations = hashRelations;
         _users = users;
         _collectionMonitor = collectionMonitor;
         _serverHealthMonitor = serverHealthMonitor;
@@ -247,6 +241,7 @@ namespace PMP::Server
                                     _generator,
                                     _history,
                                     _hashIdRegistrar,
+                                    _hashRelations,
                                     _users,
                                     _delayedStart,
                                     _scrobbling);

--- a/src/server/tcpserver.h
+++ b/src/server/tcpserver.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -33,6 +33,7 @@ namespace PMP::Server
     class DelayedStart;
     class Generator;
     class HashIdRegistrar;
+    class HashRelations;
     class History;
     class Player;
     class Scrobbling;
@@ -50,12 +51,14 @@ namespace PMP::Server
 
         bool listen(Player* player, Generator* generator, History* history,
                     HashIdRegistrar* hashIdRegistrar,
+                    HashRelations* hashRelations,
                     Users* users,
                     CollectionMonitor* collectionMonitor,
                     ServerHealthMonitor* serverHealthMonitor,
                     Scrobbling* scrobbling,
                     DelayedStart* delayedStart,
-                    const QHostAddress& address = QHostAddress::Any, quint16 port = 0);
+                    const QHostAddress& address = QHostAddress::Any,
+                    quint16 port = 0);
 
         QString errorString() const;
 
@@ -88,15 +91,16 @@ namespace PMP::Server
         QString _caption;
         QString _serverPassword;
         ServerSettings* _settings;
-        Player* _player;
-        Generator* _generator;
-        History* _history;
+        Player* _player { nullptr };
+        Generator* _generator { nullptr };
+        History* _history { nullptr };
         HashIdRegistrar* _hashIdRegistrar { nullptr };
-        Users* _users;
-        CollectionMonitor* _collectionMonitor;
-        ServerHealthMonitor* _serverHealthMonitor;
-        Scrobbling* _scrobbling;
-        DelayedStart* _delayedStart;
+        HashRelations* _hashRelations { nullptr };
+        Users* _users { nullptr };
+        CollectionMonitor* _collectionMonitor { nullptr };
+        ServerHealthMonitor* _serverHealthMonitor { nullptr };
+        Scrobbling* _scrobbling { nullptr };
+        DelayedStart* _delayedStart { nullptr };
         QTcpServer* _server;
         QUdpSocket* _udpSocket;
         QTimer* _broadcastTimer;


### PR DESCRIPTION
When fetching the history of an individual track, take hash equivalences into account. This means that we will return history entries of all hashes that are considered to be equivalent to the hash that was requested.

This is a change in the server only, so older clients will also benefit from this improvement.