### PR TITLE
Retrieving track info of a single track

### DIFF
--- a/src/client/collectionwatcher.h
+++ b/src/client/collectionwatcher.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,6 +20,10 @@
 #ifndef PMP_CLIENT_COLLECTIONWATCHER_H
 #define PMP_CLIENT_COLLECTIONWATCHER_H
 
+#include "common/future.h"
+#include "common/nullable.h"
+#include "common/resultmessageerrorcode.h"
+
 #include "collectiontrackinfo.h"
 
 #include <QHash>
@@ -39,7 +43,9 @@ namespace PMP::Client
         virtual bool downloadingInProgress() const = 0;
 
         virtual QHash<LocalHashId, CollectionTrackInfo> getCollection() = 0;
-        virtual CollectionTrackInfo getTrack(LocalHashId hashId) = 0;
+        virtual Nullable<CollectionTrackInfo> getTrackFromCache(LocalHashId hashId) = 0;
+        virtual Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                                LocalHashId hashId) = 0;
 
     Q_SIGNALS:
         void downloadingInProgressChanged();

--- a/src/client/collectionwatcherimpl.h
+++ b/src/client/collectionwatcherimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -41,7 +41,9 @@ namespace PMP::Client
         bool downloadingInProgress() const override;
 
         QHash<LocalHashId, CollectionTrackInfo> getCollection() override;
-        CollectionTrackInfo getTrack(LocalHashId hashId) override;
+        Nullable<CollectionTrackInfo> getTrackFromCache(LocalHashId hashId) override;
+        Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                            LocalHashId hashId) override;
 
     private Q_SLOTS:
         void onConnected();
@@ -54,6 +56,8 @@ namespace PMP::Client
         void onCollectionTracksChanged(QVector<PMP::Client::CollectionTrackInfo> changes);
 
     private:
+        Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfoInternal(
+                                                                      LocalHashId hashId);
         void startDownload();
         void updateTrackAvailability(QVector<LocalHashId> hashes, bool available);
         void updateTrackData(CollectionTrackInfo const& track);

--- a/src/client/servercapabilities.h
+++ b/src/client/servercapabilities.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -36,6 +36,7 @@ namespace PMP::Client
         virtual bool supportsInsertingBarriers() const = 0;
         virtual bool supportsAlbumArtist() const = 0;
         virtual bool supportsRequestingPersonalTrackHistory() const = 0;
+        virtual bool supportsRequestingIndividualTrackInfo() const = 0;
 
     protected:
         ServerCapabilities() {}

--- a/src/client/servercapabilitiesimpl.cpp
+++ b/src/client/servercapabilitiesimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -75,5 +75,10 @@ namespace PMP::Client
     bool ServerCapabilitiesImpl::supportsRequestingPersonalTrackHistory() const
     {
         return _serverProtocolNumber >= 25;
+    }
+
+    bool ServerCapabilitiesImpl::supportsRequestingIndividualTrackInfo() const
+    {
+        return _serverProtocolNumber >= 27;
     }
 }

--- a/src/client/servercapabilitiesimpl.h
+++ b/src/client/servercapabilitiesimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -40,6 +40,7 @@ namespace PMP::Client
         bool supportsInsertingBarriers() const override;
         bool supportsAlbumArtist() const override;
         bool supportsRequestingPersonalTrackHistory() const override;
+        bool supportsRequestingIndividualTrackInfo() const override;
 
     private:
         int _serverProtocolNumber;

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -155,6 +155,10 @@ namespace PMP::Client
                                                          QString albumArtist,
                                                          qint32 lengthInMilliseconds)
     {
+        Q_UNUSED(isAvailable)
+        Q_UNUSED(albumArtist)
+        Q_UNUSED(lengthInMilliseconds)
+
         qWarning() << "ResultHandler does not handle hash info;"
                    << " ref:" << clientReference
                    << " title:" << title << " artist:" << artist << " album:" << album;

--- a/src/client/serverconnection.h
+++ b/src/client/serverconnection.h
@@ -93,6 +93,7 @@ namespace PMP::Client
         class QueueEntryInsertionResultHandler;
         class DuplicationResultHandler;
         class HistoryFragmentResultHandler;
+        class HashInfoResultHandler;
 
     public:
         explicit ServerConnection(QObject* parent,
@@ -129,6 +130,8 @@ namespace PMP::Client
         RequestID insertSpecialQueueItemAtIndex(SpecialQueueItemType itemType, int index,
                                        QueueIndexType indexType = QueueIndexType::Normal);
         RequestID duplicateQueueEntry(uint queueID);
+        Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                                    LocalHashId hashId);
         Future<HistoryFragment, AnyResultMessageCode> getPersonalTrackHistory(
                                                         LocalHashId hashId, uint userId,
                                                         int limit, uint startId = 0);
@@ -180,6 +183,8 @@ namespace PMP::Client
         void sendQueueEntryHashRequest(QList<uint> const& queueIDs);
 
         void sendHashUserDataRequest(quint32 userId, QList<LocalHashId> const& hashes);
+        Future<CollectionTrackInfo, AnyResultMessageCode> sendHashInfoRequest(
+                                                                    LocalHashId hashId);
         Future<HistoryFragment, AnyResultMessageCode> sendHashHistoryRequest(
                                                         LocalHashId hashId, uint userId,
                                                         int limit, uint startId);
@@ -385,6 +390,7 @@ namespace PMP::Client
                                         ServerMessageType messageType);
 
         void parseHashUserDataMessage(QByteArray const& message);
+        void parseHashInfoReply(QByteArray const& message);
         void parseHistoryFragmentMessage(QByteArray const& message);
         void parseNewHistoryEntryMessage(QByteArray const& message);
         void parsePlayerHistoryMessage(QByteArray const& message);

--- a/src/cmd-remote/cmd-remote-main.cpp
+++ b/src/cmd-remote/cmd-remote-main.cpp
@@ -67,6 +67,7 @@ usage:
     delayedstart wait <number> <time unit>: activate delayed start (see below)
     delayedstart at [<date>] <time>: activate delayed start (see below)
     delayedstart abort|cancel: cancel delayed start (see below)
+    trackinfo <hash>: get track information like artist, title, length, etc.
     trackstats <hash>: get track statistics
     trackhistory <hash>: get personal listening history for a track
     serverversion: get server version information
@@ -173,6 +174,14 @@ usage:
     reached yet can still be cancelled with 'cancel' or 'abort'. Delayed
     start is cancelled automatically when playback is started before the
     deadline.
+
+  'trackinfo' command:
+    trackinfo <hash>: get track information like artist, title, length, etc.
+
+    Retrieves title, artist, album, album artist, length and availability
+    for the track that was specified as an argument.
+    The hash of a track can be obtained with the 'track info' dialog in the
+    GUI Remote or with the command-line hash tool.
 
   'trackstats' command:
     trackstats <hash>: get track statistics for the current user

--- a/src/cmd-remote/commandparser.cpp
+++ b/src/cmd-remote/commandparser.cpp
@@ -359,6 +359,10 @@ namespace PMP
         {
             parseDelayedStartCommand(args);
         }
+        else if (command == "trackinfo")
+        {
+            parseTrackInfoCommand(args);
+        }
         else if (command == "trackstats")
         {
             parseTrackStatsCommand(args);
@@ -745,6 +749,24 @@ namespace PMP
         }
 
         _command = new DelayedStartWaitCommand(number * unitMilliseconds);
+    }
+
+    void CommandParser::parseTrackInfoCommand(CommandArguments arguments)
+    {
+        if (arguments.noCurrent() || arguments.haveMore())
+        {
+            _errorMessage = "Command 'trackinfo' requires exactly one argument!";
+            return;
+        }
+
+        auto hash = arguments.tryParseTrackHash();
+        if (hash.isNull())
+        {
+            _errorMessage = QString("Not a track hash: %1").arg(arguments.current());
+            return;
+        }
+
+        _command = new TrackInfoCommand(hash);
     }
 
     void CommandParser::parseTrackStatsCommand(CommandArguments arguments)

--- a/src/cmd-remote/commandparser.h
+++ b/src/cmd-remote/commandparser.h
@@ -128,6 +128,7 @@ namespace PMP
         void parseDelayedStartCommand(CommandArguments arguments);
         void parseDelayedStartAt(CommandArguments& arguments);
         void parseDelayedStartWait(CommandArguments& arguments);
+        void parseTrackInfoCommand(CommandArguments arguments);
         void parseTrackStatsCommand(CommandArguments arguments);
         void parseTrackHistoryCommand(CommandArguments arguments);
         void parseScrobblingCommand(CommandArguments arguments);

--- a/src/cmd-remote/miscellaneouscommands.h
+++ b/src/cmd-remote/miscellaneouscommands.h
@@ -28,6 +28,7 @@
 
 namespace PMP::Client
 {
+    class CollectionTrackInfo;
     class CurrentTrackMonitor;
     class DynamicModeController;
     class PlayerController;
@@ -98,6 +99,23 @@ namespace PMP
 
     private:
         int _volume;
+    };
+
+    class TrackInfoCommand : public CommandBase
+    {
+        Q_OBJECT
+    public:
+        explicit TrackInfoCommand(FileHash const& hash);
+
+        bool requiresAuthentication() const override;
+
+    protected:
+        void run(Client::ServerInterface* serverInterface) override;
+
+    private:
+        void printTrackInfo(Client::CollectionTrackInfo& trackInfo);
+
+        FileHash _hash;
     };
 
     class TrackStatsCommand : public CommandBase

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -63,6 +63,7 @@ Changes for each version:
   24: server msgs 18 & 19: add album artist to track info
   25: client msg 27, server msg 36, error codes 26 & 120 & 121: fetch personal track history
   26: parameterless actions 60 & 61, server msg 37: full indexation and quick scan for new files
+  27: client msg 28, server msg 38: requesting individual track info
 */
 
 namespace PMP
@@ -111,6 +112,7 @@ namespace PMP
         ExtensionResultMessage = 35,
         HistoryFragmentMessage = 36,
         IndexationStatusMessage = 37,
+        HashInfoReply = 38,
     };
 
     enum class ScrobblingServerMessageType : quint8
@@ -150,6 +152,7 @@ namespace PMP
         KeepAliveMessage = 25,
         ActivateDelayedStartRequest = 26,
         PersonalHistoryRequest = 27,
+        HashInfoRequest = 28,
     };
 
     enum class ScrobblingClientMessageType : quint8

--- a/src/gui-remote/trackinfodialog.cpp
+++ b/src/gui-remote/trackinfodialog.cpp
@@ -61,15 +61,16 @@ namespace PMP
         fillQueueId();
         fillHash();
 
-        auto trackInfo = serverInterface->collectionWatcher().getTrack(hashId);
+        auto trackInfoOrNull =
+            serverInterface->collectionWatcher().getTrackFromCache(hashId);
 
-        if (trackInfo.hashId().isZero())
-        { /* not found? */
+        if (trackInfoOrNull == null) /* not found? */
+        {
             clearTrackDetails();
         }
         else
         {
-            fillTrackDetails(trackInfo);
+            fillTrackDetails(trackInfoOrNull.value());
         }
 
         fillUserData(_trackHashId, _userId);

--- a/src/server/connectedclient.h
+++ b/src/server/connectedclient.h
@@ -189,6 +189,7 @@ namespace PMP::Server
         void sendQueueHistoryMessage(int limit);
         void sendHistoryFragmentMessage(uint clientReference, HistoryFragment fragment);
         void sendHashUserDataMessage(quint32 userId, QVector<HashStats> stats);
+        void sendHashInfoReply(uint clientReference, CollectionTrackInfo info);
         void sendServerNameMessage();
         void sendServerHealthMessageIfNotEverythingOkay();
         void sendServerHealthMessage();
@@ -241,6 +242,7 @@ namespace PMP::Server
         void parseQueueEntryDuplicationRequest(QByteArray const& message);
         void parseQueueEntryMoveRequestMessage(QByteArray const& message);
         void parseHashUserDataRequest(QByteArray const& message);
+        void parseHashInfoRequest(QByteArray const& message);
         void parsePersonalHistoryRequest(QByteArray const& message);
         void parsePlayerHistoryRequest(QByteArray const& message);
         void parseCurrentUserScrobblingProviderInfoRequestMessage(

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -672,6 +672,22 @@ namespace PMP::Server
             Q_EMIT hashUserDataChangedOrAvailable(userId, hashStatsAlreadyAvailable);
     }
 
+    Future<CollectionTrackInfo, Result> ServerInterface::getHashInfo(FileHash hash)
+    {
+        /* note: client does not need to be logged in for this */
+
+        if (hash.isNull())
+            return FutureError(Error::hashIsNull());
+
+        auto maybeHashId = _hashIdRegistrar->getIdForHash(hash);
+        if (maybeHashId == null)
+            return FutureError(Error::hashIsUnknown());
+
+        auto hashInfo = _player->resolver().getHashTrackInfo(maybeHashId.value());
+
+        return FutureResult(hashInfo);
+    }
+
     void ServerInterface::shutDownServer()
     {
         if (!isLoggedIn()) return;

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -29,6 +29,7 @@
 #include "common/startstopeventstatus.h"
 #include "common/versioninfo.h"
 
+#include "collectiontrackinfo.h"
 #include "hashstats.h"
 #include "historyentry.h"
 #include "result.h"
@@ -147,6 +148,7 @@ namespace PMP::Server
         void setTrackRepetitionAvoidanceSeconds(int seconds);
 
         void requestHashUserData(quint32 userId, QVector<FileHash> hashes);
+        Future<CollectionTrackInfo, Result> getHashInfo(FileHash hash);
 
         void shutDownServer();
         void shutDownServer(QString serverPassword);

--- a/testing/test_sortedcollectiontablemodel.cpp
+++ b/testing/test_sortedcollectiontablemodel.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2023-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -294,6 +294,8 @@ void TestSortedCollectionTableModel::trackTitleUpdateCausesMoveToLastPosition()
     verifyInnerToOuterMapping(model);
 }
 
+/* =========== */
+
 #define NOT_IMPLEMENTED { Q_UNREACHABLE(); }
 
 /* =========== */
@@ -548,7 +550,14 @@ QHash<LocalHashId, CollectionTrackInfo> CollectionWatcherMock::getCollection()
     return _collection;
 }
 
-CollectionTrackInfo CollectionWatcherMock::getTrack(LocalHashId hashId)
+Nullable<CollectionTrackInfo> CollectionWatcherMock::getTrackFromCache(LocalHashId hashId)
+{
+    Q_UNUSED(hashId)
+    NOT_IMPLEMENTED
+}
+
+Future<CollectionTrackInfo, AnyResultMessageCode> CollectionWatcherMock::getTrackInfo(
+                                                                       LocalHashId hashId)
 {
     Q_UNUSED(hashId)
     NOT_IMPLEMENTED

--- a/testing/test_sortedcollectiontablemodel.h
+++ b/testing/test_sortedcollectiontablemodel.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2023-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -133,7 +133,9 @@ public:
     bool downloadingInProgress() const override;
 
     QHash<LocalHashId, CollectionTrackInfo> getCollection() override;
-    CollectionTrackInfo getTrack(LocalHashId hashId) override;
+    Nullable<CollectionTrackInfo> getTrackFromCache(LocalHashId hashId) override;
+    Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                             LocalHashId hashId) override;
 
 private:
     QHash<LocalHashId, CollectionTrackInfo> _collection;


### PR DESCRIPTION
Extend the network protocol in order to make it possible to get title,
artist, length, and other properties of a single track. Until now it
was only possible to obtain this information by downloading the entire
list of tracks from the music collection to the client.

Add the "trackinfo" command to the command-line client. This command
prints title, artist, album, album artist, length, and availability of
a single track.

The track info dialog of the desktop client can now display the
information of a track before the entire collection has been downloaded
to the client.