### PR TITLE
Display server version in the 'About PMP' dialog

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(PMP_COMMON_SOURCES
     common/tagdata.cpp
     common/tribool.cpp
     common/util.cpp
+    common/versioninfo.cpp
 )
 set(PMP_COMMON_HEADERS
     common/powermanagement.h

--- a/src/common/future.h
+++ b/src/common/future.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -81,6 +81,11 @@ namespace PMP
         void addFailureListener(QObject* receiver, std::function<void (ErrorType)> f)
         {
             _storage->addFailureListener(receiver, f);
+        }
+
+        Nullable<ResultOrError<ResultType, ErrorType>> resultOrErrorIfFinished()
+        {
+            return _storage->getResultOrErrorIfFinished();
         }
 
         ResultOrError<ResultType, ErrorType> resultOrError()

--- a/src/common/futureinternals.h
+++ b/src/common/futureinternals.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -205,6 +205,19 @@ namespace PMP
                 };
 
             addFailureListener(listener);
+        }
+
+        Nullable<ResultOrError<ResultType, ErrorType>> getResultOrErrorIfFinished()
+        {
+            QMutexLocker lock(&_mutex);
+
+            if (!_finished)
+                return null;
+
+            if (_result.hasValue())
+                return ResultOrError<ResultType, ErrorType>::fromResult(_result.value());
+            else
+                return ResultOrError<ResultType, ErrorType>::fromError(_error.value());
         }
 
         ResultOrError<ResultType, ErrorType> getResultOrError()

--- a/src/common/versioninfo.cpp
+++ b/src/common/versioninfo.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,25 +17,20 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_VERSIONINFO_H
-#define PMP_VERSIONINFO_H
+#include "versioninfo.h"
 
-#include <QMetaType>
-#include <QString>
+#include "common/version.h"
 
 namespace PMP
 {
-    struct VersionInfo
+    VersionInfo VersionInfo::current()
     {
-        QString programName;
-        QString versionForDisplay;
-        QString vcsBuild;
-        QString vcsBranch;
+        VersionInfo info;
+        info.programName = PMP_PRODUCT_NAME;
+        info.versionForDisplay = PMP_VERSION_DISPLAY;
+        info.vcsBuild = VCS_REVISION_LONG;
+        info.vcsBranch = VCS_BRANCH;
 
-        static VersionInfo current();
-    };
+        return info;
+    }
 }
-
-Q_DECLARE_METATYPE(PMP::VersionInfo)
-
-#endif

--- a/src/gui-remote/mainwindow.h
+++ b/src/gui-remote/mainwindow.h
@@ -48,6 +48,7 @@ namespace PMP
     class PowerManagement;
     class UserAccountCreationWidget;
     class UserPickerWidget;
+    struct VersionInfo;
 
     class MainWindow : public QMainWindow
     {
@@ -105,6 +106,8 @@ namespace PMP
 
         void connectErrorPopupToActionResult(SimpleFuture<AnyResultMessageCode> future,
                                              QString failureText);
+
+        QString getVersionText(VersionInfo const& versionInfo);
 
         NotificationBar* _notificationBar { nullptr };
         QLabel* _leftStatus { nullptr };

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -22,7 +22,6 @@
 #include "common/concurrent.h"
 #include "common/containerutil.h"
 #include "common/promise.h"
-#include "common/version.h"
 
 #include "database.h"
 #include "delayedstart.h"
@@ -140,13 +139,7 @@ namespace PMP::Server
 
     VersionInfo ServerInterface::getServerVersionInfo() const
     {
-        VersionInfo info;
-        info.programName = PMP_PRODUCT_NAME;
-        info.versionForDisplay = PMP_VERSION_DISPLAY;
-        info.vcsBuild = VCS_REVISION_LONG;
-        info.vcsBranch = VCS_BRANCH;
-
-        return info;
+        return VersionInfo::current();
     }
 
     ResultOrError<QUuid, Result> ServerInterface::getDatabaseUuid() const


### PR DESCRIPTION
Display version information for both client and server in the 'About PMP' dialog.

The display of server version requires a server that is recent enough to support supplying version information. This capability was added shorty after the 0.2 release, when the 'serverversion' command was added to the command-line client.