### PR TITLE
Replace password score with password rating

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -120,7 +120,6 @@ USER FRIENDLINESS
 
  * provide 'forgot password' functionality to enable a user to reset their password
  ** work around the need for a full indexation at server startup
- * when creating a new account, explain the meaning of the password score
  * GUI remote: after login it should show what server it is connected to somehow
  * display the title/artist of the track currently playing in the window title of the remote
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(PMP_COMMON_SOURCES
     common/networkprotocolextensions.cpp
     common/networkutil.cpp
     common/obfuscator.cpp
+    common/passwordstrengthevaluator.cpp
     common/powermanagement.cpp
     common/scrobblerstatus.cpp
     common/scrobblingprovider.cpp

--- a/src/common/networkprotocol.cpp
+++ b/src/common/networkprotocol.cpp
@@ -174,66 +174,6 @@ namespace PMP
         }
     }
 
-    int NetworkProtocol::ratePassword(QString password)
-    {
-        int rating = 0;
-        for (int i = 0; i < password.size(); ++i)
-        {
-            rating += 3;
-            QChar c = password[i];
-
-            if (c.isDigit())
-            {
-                rating += 1; /* digits are slightly better than lowercase letters */
-            }
-            else if (c.isLetter())
-            {
-                if (c.isLower())
-                {
-                    /* lowercase letters worth the least */
-                }
-                else
-                {
-                    rating += 2; /* uppercase letters are better than digits */
-                }
-            }
-            else
-            {
-                rating += 7;
-            }
-        }
-
-        int lastDiff = 0;
-        int diffConstantCount = 0;
-        for (int i = 1; i < password.size(); ++i)
-        {
-            QChar prevC = password[i - 1];
-            int prevN = prevC.unicode();
-            QChar curC = password[i];
-            int curN = curC.unicode();
-
-            /* punish patterns such as "eeeee", "123456", "98765", "ghijklm" etc... */
-            int diff = curN - prevN;
-            if (diff <= 1 && diff >= -1)
-            {
-                rating -= 1;
-            }
-            if (diff == lastDiff)
-            {
-                diffConstantCount += 1;
-                rating -= diffConstantCount;
-            }
-            else
-            {
-                diffConstantCount = 0;
-            }
-
-            lastDiff = diff;
-        }
-
-        return rating;
-    }
-
     QByteArray NetworkProtocol::hashPassword(QByteArray const& salt, QString password)
     {
         QCryptographicHash hasher(QCryptographicHash::Sha256);

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -215,8 +215,6 @@ namespace PMP
         static quint8 encode(ScrobblerStatus status);
         static ScrobblerStatus decodeScrobblerStatus(quint8 status);
 
-        static int ratePassword(QString password);
-
         static QByteArray hashPassword(QByteArray const& salt, QString password);
         static QByteArray hashPasswordForSession(QByteArray const& userSalt,
                                                  QByteArray const& sessionSalt,

--- a/src/common/passwordstrengthevaluator.cpp
+++ b/src/common/passwordstrengthevaluator.cpp
@@ -1,0 +1,251 @@
+/*
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "passwordstrengthevaluator.h"
+
+//#include <QtDebug>
+#include <QVector>
+
+namespace PMP
+{
+    namespace
+    {
+        struct BlockFeatures
+        {
+            bool hasLowercaseLetters { false };
+            bool hasUppercaseLetters { false };
+            bool hasDigits { false };
+            bool hasSpecialCharacters { false };
+
+            bool isComplete { false };
+        };
+
+        QVector<BlockFeatures> getBlocksForPassword(QString const& password)
+        {
+            QVector<BlockFeatures> blocks { BlockFeatures() };
+
+            for (int i = 0; i < password.size(); ++i)
+            {
+                auto& currentBlock = blocks.last();
+
+                QChar c = password[i];
+
+                if (c.isDigit())
+                {
+                    currentBlock.hasDigits = true;
+                }
+                else if (c.isLetter())
+                {
+                    if (c.isLower())
+                        currentBlock.hasLowercaseLetters = true;
+                    else
+                        currentBlock.hasUppercaseLetters = true;
+                }
+                else
+                {
+                    currentBlock.hasSpecialCharacters = true;
+                }
+
+                if ((i + 1) % 4 == 0) /* block complete? */
+                {
+                    currentBlock.isComplete = true;
+
+                    blocks.append(BlockFeatures());
+                }
+            }
+
+            return blocks;
+        }
+
+        int getBlockRating(BlockFeatures const& block)
+        {
+            int featuresBitSet = (block.hasLowercaseLetters ? 0b1000 : 0)
+                                 + (block.hasUppercaseLetters ? 0b0100 : 0)
+                                 + (block.hasDigits ? 0b0010 : 0)
+                                 + (block.hasSpecialCharacters ? 0b0001 : 0);
+
+            int score;
+            switch (featuresBitSet)
+            {
+                /* only a single feature */
+            case 0b1000: score = 5; break;
+            case 0b0100: score = 5; break;
+            case 0b0010: score = 5; break;
+            case 0b0001: score = 6; break;
+
+                /* two features */
+            case 0b1100: score = 10; break;
+            case 0b1010: score = 10; break;
+            case 0b1001: score = 11; break;
+            case 0b0110: score = 10; break;
+            case 0b0101: score = 11; break;
+            case 0b0011: score = 11; break;
+
+                /* three features */
+            case 0b1110: score = 15; break;
+            case 0b1101: score = 16; break;
+            case 0b1011: score = 16; break;
+            case 0b0111: score = 16; break;
+
+                /* four features */
+            case 0b1111: score = 21; break;
+
+                /* zero features / fallback */
+            case 0b0000: default: score = 0; break;
+            }
+
+            if (!block.isComplete)
+                score = (score - 1) / 2;
+
+            return score;
+        }
+
+        int sumOfBlockRatings(QVector<BlockFeatures> const& blocks)
+        {
+            BlockFeatures wholePasswordFeatures;
+
+            int sum = 0;
+            for (auto& block : blocks)
+            {
+                wholePasswordFeatures.hasLowercaseLetters |= block.hasLowercaseLetters;
+                wholePasswordFeatures.hasUppercaseLetters |= block.hasUppercaseLetters;
+                wholePasswordFeatures.hasDigits |= block.hasDigits;
+                wholePasswordFeatures.hasSpecialCharacters |= block.hasSpecialCharacters;
+
+                sum += getBlockRating(block);
+            }
+
+            wholePasswordFeatures.isComplete = true;
+
+            sum += getBlockRating(wholePasswordFeatures);
+
+            return sum;
+        }
+
+        /*
+        QDebug operator<<(QDebug debug, PasswordStrengthRating rating)
+        {
+            switch (rating)
+            {
+            case PasswordStrengthRating::TooWeak: debug << "too weak"; return debug;
+            case PasswordStrengthRating::Acceptable: debug << "acceptable";return debug;
+            case PasswordStrengthRating::Good: debug << "good"; return debug;
+            case PasswordStrengthRating::VeryGood: debug << "very good"; return debug;
+            case PasswordStrengthRating::Excellent: debug << "excellent"; return debug;
+            }
+
+            debug << int(rating);
+            return debug;
+        }
+        */
+    }
+
+    PasswordStrengthRating PasswordStrengthEvaluator::getPasswordRating(
+                                                                const QString& password)
+    {
+        int score = getPasswordScore(password);
+
+        return convertScoreToRating(score);
+    }
+
+    int PasswordStrengthEvaluator::getPasswordScore(const QString& password)
+    {
+        int passwordCharCount = password.size();
+
+        auto const blocks = getBlocksForPassword(password);
+        int blockRatingsTotal = sumOfBlockRatings(blocks);
+
+        int pointsToSubtract = pointsToSubtractForPatterns(password);
+
+        int total = passwordCharCount + blockRatingsTotal - pointsToSubtract;
+
+        /* ONLY FOR DEBUGGING!
+        qDebug() << "score of" << password << ":"
+                 << passwordCharCount << "+" << blockRatingsTotal
+                 << "-" << pointsToSubtract << "=" << total
+                 << "<--" << ratingForScore(total);
+        */
+
+        return total;
+    }
+
+    PasswordStrengthRating PasswordStrengthEvaluator::convertScoreToRating(int score)
+    {
+        if (score < 35)
+            return PasswordStrengthRating::TooWeak; /* 0 to 34 */
+
+        if (score < 47)
+            return PasswordStrengthRating::Acceptable; /* 35 to 46 */
+
+        if (score < 59)
+            return PasswordStrengthRating::Good; /* 47 to 58 */
+
+        if (score < 71)
+            return PasswordStrengthRating::VeryGood; /* 59 to 70 */
+
+        return PasswordStrengthRating::Excellent; /* 71 and up */
+    }
+
+    int PasswordStrengthEvaluator::pointsToSubtractForPatterns(const QString& password)
+    {
+        int pointsToSubtract = 0;
+
+        bool inPattern = false;
+        int currentPatternPoints = 0;
+
+        for (int i = 2; i < password.size(); ++i)
+        {
+            QChar character1 = password[i - 2];
+            int character1Numeric = character1.unicode();
+            QChar character2 = password[i - 1];
+            int character2Numeric = character2.unicode();
+            QChar character3 = password[i];
+            int character3Numberic = character3.unicode();
+
+            int diff1 = character2Numeric - character1Numeric;
+            int diff2 = character3Numberic - character2Numeric;
+
+            /* punish patterns such as "eeeee", "123456", "98765", "ghijklm" etc... */
+            if (diff1 == diff2)
+            {
+                if (inPattern)
+                {
+                    currentPatternPoints += 8;
+                }
+                else
+                {
+                    currentPatternPoints += 4;
+                }
+
+                inPattern = true;
+            }
+            else
+            {
+                pointsToSubtract += currentPatternPoints;
+
+                inPattern = false;
+                currentPatternPoints = 0;
+            }
+        }
+
+        pointsToSubtract += currentPatternPoints;
+
+        return pointsToSubtract;
+    }
+}

--- a/src/common/passwordstrengthevaluator.h
+++ b/src/common/passwordstrengthevaluator.h
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_PASSWORDSTRENGTHEVALUATOR_H
+#define PMP_PASSWORDSTRENGTHEVALUATOR_H
+
+#include <QString>
+
+namespace PMP
+{
+    enum class PasswordStrengthRating
+    {
+        TooWeak,
+        Acceptable,
+        Good,
+        VeryGood,
+        Excellent,
+    };
+
+    class PasswordStrengthEvaluator
+    {
+    public:
+        static PasswordStrengthRating getPasswordRating(QString const& password);
+
+    private:
+        PasswordStrengthEvaluator();
+
+        static int getPasswordScore(QString const& password);
+        static PasswordStrengthRating convertScoreToRating(int score);
+        static int pointsToSubtractForPatterns(QString const& password);
+    };
+}
+#endif

--- a/src/gui-remote/useraccountcreationwidget.h
+++ b/src/gui-remote/useraccountcreationwidget.h
@@ -20,6 +20,7 @@
 #ifndef PMP_USERACCOUNTCREATIONWIDGET_H
 #define PMP_USERACCOUNTCREATIONWIDGET_H
 
+#include "common/passwordstrengthevaluator.h"
 #include "common/userregistrationerror.h"
 
 #include <QString>
@@ -57,6 +58,8 @@ namespace PMP
         void userAccountCreationError(QString login, UserRegistrationError errorType);
 
     private:
+        QString ratingToString(PasswordStrengthRating rating);
+
         Ui::UserAccountCreationWidget* _ui;
         Client::AuthenticationController* _authenticationController;
     };

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -157,6 +157,16 @@ target_link_libraries(test_networkprotocol ${TAGLIB_LIBRARIES})
 add_test(test_networkprotocol test_networkprotocol)
 
 
+# TestPasswordStrengthEvaluator
+qt5_wrap_cpp(PMP_TestPasswordStrengthEvaluator_MOCS test_passwordstrengthevaluator.h)
+add_executable(test_passwordstrengthevaluator test_passwordstrengthevaluator.cpp
+    ${PMP_TestPasswordStrengthEvaluator_MOCS}
+    ${CMAKE_SOURCE_DIR}/src/common/passwordstrengthevaluator.cpp
+)
+target_link_libraries(test_passwordstrengthevaluator Qt5::Core Qt5::Test)
+add_test(test_passwordstrengthevaluator test_passwordstrengthevaluator)
+
+
 # TestObfuscator
 qt5_wrap_cpp(PMP_TestObfuscator_MOCS test_obfuscator.h)
 add_executable(test_obfuscator test_obfuscator.cpp

--- a/testing/test_passwordstrengthevaluator.cpp
+++ b/testing/test_passwordstrengthevaluator.cpp
@@ -1,0 +1,66 @@
+/*
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "test_passwordstrengthevaluator.h"
+
+#include "common/passwordstrengthevaluator.h"
+
+#include <QtTest/QTest>
+#include <QVector>
+
+using namespace PMP;
+
+void TestPasswordStrengthEvaluator::passwordsThatAreTooWeak()
+{
+    const QVector<QString> weakPasswords
+        {
+            "test",
+            "iamweak",
+            "password",
+            "password123",
+            "123456789",
+            "abcdefghijklm",
+            "hunter2",
+            "happy!",
+            "MyMusic",
+        };
+
+    for (auto& weakPassword : weakPasswords)
+    {
+        auto rating = PasswordStrengthEvaluator::getPasswordRating(weakPassword);
+        QCOMPARE(rating, PasswordStrengthRating::TooWeak);
+    }
+}
+
+void TestPasswordStrengthEvaluator::passwordsThatAreNotWeak()
+{
+    const QVector<QString> passwordsNotWeak
+        {
+            "Rue4cG&mhKd",
+            "90846703458154698273",
+        };
+
+    for (auto& acceptablePassword : passwordsNotWeak)
+    {
+        auto rating = PasswordStrengthEvaluator::getPasswordRating(acceptablePassword);
+        QVERIFY(rating != PasswordStrengthRating::TooWeak);
+    }
+}
+
+QTEST_MAIN(TestPasswordStrengthEvaluator)

--- a/testing/test_passwordstrengthevaluator.h
+++ b/testing/test_passwordstrengthevaluator.h
@@ -1,0 +1,33 @@
+/*
+    Copyright (C) 2024, Kevin Andre <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TESTPASSWORDSTRENGTHEVALUATOR_H
+#define TESTPASSWORDSTRENGTHEVALUATOR_H
+
+#include <QObject>
+
+class TestPasswordStrengthEvaluator : public QObject
+{
+    Q_OBJECT
+private Q_SLOTS:
+    void passwordsThatAreTooWeak();
+    void passwordsThatAreNotWeak();
+};
+
+#endif


### PR DESCRIPTION
When creating a new user account, a password score was displayed. This is now replaced with a password rating: "too weak", "acceptable", "good" etc. The underlying logic to evaluate password strength is now different and a bit more demanding.