### PR TITLE
Searching for a track by its hash

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -70,7 +70,6 @@ IDEAS
  * music collection: provide general statistics (e.g. total number of files present, number of hashes with a file...)
  * music collection: add quick search function, for searching while leaving the current filters unchanged
  * music collection: new action: add track before first interruption (break/barrier)
- * music collection: search for tracks by hash
  *** dynamic mode: detect and prevent track repetition with different hash values
  *** dynamic mode: artist repetition avoidance
  * dynamic mode: ability to force a track to be played regularly (e.g. at least daily)

--- a/src/client/collectionwatcher.h
+++ b/src/client/collectionwatcher.h
@@ -20,6 +20,7 @@
 #ifndef PMP_CLIENT_COLLECTIONWATCHER_H
 #define PMP_CLIENT_COLLECTIONWATCHER_H
 
+#include "common/filehash.h"
 #include "common/future.h"
 #include "common/nullable.h"
 #include "common/resultmessageerrorcode.h"
@@ -46,6 +47,8 @@ namespace PMP::Client
         virtual Nullable<CollectionTrackInfo> getTrackFromCache(LocalHashId hashId) = 0;
         virtual Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
                                                                 LocalHashId hashId) = 0;
+        virtual Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                                FileHash const& hash) = 0;
 
     Q_SIGNALS:
         void downloadingInProgressChanged();

--- a/src/client/collectionwatcherimpl.h
+++ b/src/client/collectionwatcherimpl.h
@@ -44,6 +44,8 @@ namespace PMP::Client
         Nullable<CollectionTrackInfo> getTrackFromCache(LocalHashId hashId) override;
         Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
                                                             LocalHashId hashId) override;
+        Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                        FileHash const& hash) override;
 
     private Q_SLOTS:
         void onConnected();
@@ -58,6 +60,8 @@ namespace PMP::Client
     private:
         Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfoInternal(
                                                                       LocalHashId hashId);
+        Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfoInternal(
+                                                                    FileHash const& hash);
         void startDownload();
         void updateTrackAvailability(QVector<LocalHashId> hashes, bool available);
         void updateTrackData(CollectionTrackInfo const& track);

--- a/src/client/serverconnection.h
+++ b/src/client/serverconnection.h
@@ -21,6 +21,7 @@
 #define PMP_CLIENT_SERVERCONNECTION_H
 
 #include "common/disconnectreason.h"
+#include "common/filehash.h"
 #include "common/future.h"
 #include "common/networkprotocol.h"
 #include "common/networkprotocolextensions.h"
@@ -132,6 +133,8 @@ namespace PMP::Client
         RequestID duplicateQueueEntry(uint queueID);
         Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
                                                                     LocalHashId hashId);
+        Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                                    FileHash const& hash);
         Future<HistoryFragment, AnyResultMessageCode> getPersonalTrackHistory(
                                                         LocalHashId hashId, uint userId,
                                                         int limit, uint startId = 0);
@@ -184,7 +187,7 @@ namespace PMP::Client
 
         void sendHashUserDataRequest(quint32 userId, QList<LocalHashId> const& hashes);
         Future<CollectionTrackInfo, AnyResultMessageCode> sendHashInfoRequest(
-                                                                    LocalHashId hashId);
+                                                                    const FileHash& hash);
         Future<HistoryFragment, AnyResultMessageCode> sendHashHistoryRequest(
                                                         LocalHashId hashId, uint userId,
                                                         int limit, uint startId);

--- a/src/cmd-remote/commandparser.cpp
+++ b/src/cmd-remote/commandparser.cpp
@@ -19,8 +19,6 @@
 
 #include "commandparser.h"
 
-#include "common/unicodechars.h"
-
 #include "administrativecommands.h"
 #include "historycommands.h"
 #include "miscellaneouscommands.h"
@@ -64,72 +62,7 @@ namespace PMP
 
     FileHash CommandParser::CommandArguments::tryParseTrackHash() const
     {
-        QString text = current().replace(UnicodeChars::figureDash, '-');
-
-        const auto parts = text.split(QChar('-'), Qt::KeepEmptyParts);
-        if (parts.size() != 3)
-            return {};
-
-        bool ok;
-        uint length = parts[0].toUInt(&ok);
-        if (!ok || length == 0)
-            return {};
-
-        QByteArray sha1 = tryDecodeHexWithExpectedLength(parts[1], 40);
-        if (sha1.isEmpty())
-            return {};
-
-        QByteArray md5 = tryDecodeHexWithExpectedLength(parts[2], 32);
-        if (md5.isEmpty())
-            return {};
-
-        return FileHash(length, sha1, md5);
-    }
-
-    QByteArray CommandParser::CommandArguments::tryDecodeHexWithExpectedLength(
-                                                                      const QString& text,
-                                                                      int expectedLength)
-    {
-        if (text.length() != expectedLength)
-            return {};
-
-        QByteArray hex = text.toLatin1();
-
-         /* check again (non-latin1 chars may have been removed) */
-        if (hex.length() != expectedLength)
-            return {};
-
-        if (!isHexEncoded(hex))
-            return {};
-
-        QByteArray decoded = QByteArray::fromHex(hex);
-        if (decoded.length() * 2 != expectedLength)
-            return {};
-
-        return decoded;
-    }
-
-    bool CommandParser::CommandArguments::isHexEncoded(const QByteArray& bytes)
-    {
-        if (bytes.length() % 2 != 0)
-            return false;
-
-        for (int i = 0; i < bytes.length(); ++i)
-        {
-            switch (bytes.at(i))
-            {
-            case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
-            case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
-            case '0': case '1': case '2': case '3': case '4':
-            case '5': case '6': case '7': case '8': case '9':
-                continue; /* valid character */
-
-            default:
-                return false; /* invalid character */
-            }
-        }
-
-        return true;
+        return FileHash::tryParse(current());
     }
 
     /* ===== CommandParser ===== */

--- a/src/cmd-remote/commandparser.h
+++ b/src/cmd-remote/commandparser.h
@@ -106,10 +106,6 @@ namespace PMP
             bool tryParseDate(QDate& date) const;
             FileHash tryParseTrackHash() const;
 
-            static QByteArray tryDecodeHexWithExpectedLength(QString const& text,
-                                                             int expectedLength);
-            static bool isHexEncoded(QByteArray const& bytes);
-
         private:
             QVector<QString> _arguments;
             int _currentIndex;

--- a/src/cmd-remote/miscellaneouscommands.cpp
+++ b/src/cmd-remote/miscellaneouscommands.cpp
@@ -318,11 +318,9 @@ namespace PMP
 
     void TrackInfoCommand::run(Client::ServerInterface* serverInterface)
     {
-        auto hashId = serverInterface->hashIdRepository()->getOrRegisterId(_hash);
-
         auto collectionWatcher = &serverInterface->collectionWatcher();
 
-        auto future = collectionWatcher->getTrackInfo(hashId);
+        auto future = collectionWatcher->getTrackInfo(_hash);
         addFailureHandler(future);
 
         future.addResultListener(

--- a/src/common/filehash.cpp
+++ b/src/common/filehash.cpp
@@ -27,6 +27,72 @@ namespace PMP
 {
     namespace
     {
+        bool isHexEncoded(const QByteArray& bytes)
+        {
+            if (bytes.length() % 2 != 0)
+                return false;
+
+            for (int i = 0; i < bytes.length(); ++i)
+            {
+                switch (bytes.at(i))
+                {
+                case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
+                case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
+                case '0': case '1': case '2': case '3': case '4':
+                case '5': case '6': case '7': case '8': case '9':
+                    continue; /* valid character */
+
+                default:
+                    return false; /* invalid character */
+                }
+            }
+
+            return true;
+        }
+
+        QByteArray tryDecodeHexWithExpectedLength(const QString& text, int expectedLength)
+        {
+            if (text.length() != expectedLength)
+                return {};
+
+            QByteArray hex = text.toLatin1();
+
+            /* check again (non-latin1 chars may have been removed) */
+            if (hex.length() != expectedLength)
+                return {};
+
+            if (!isHexEncoded(hex))
+                return {};
+
+            QByteArray decoded = QByteArray::fromHex(hex);
+            if (decoded.length() * 2 != expectedLength)
+                return {};
+
+            return decoded;
+        }
+
+        FileHash tryParseFileHashInternal(const QString& text)
+        {
+            const auto parts = text.split(QChar('-'), Qt::KeepEmptyParts);
+            if (parts.size() != 3)
+                return {};
+
+            bool ok;
+            uint length = parts[0].toUInt(&ok);
+            if (!ok || length == 0)
+                return {};
+
+            QByteArray sha1 = tryDecodeHexWithExpectedLength(parts[1], 40);
+            if (sha1.isEmpty())
+                return {};
+
+            QByteArray md5 = tryDecodeHexWithExpectedLength(parts[2], 32);
+            if (md5.isEmpty())
+                return {};
+
+            return FileHash(length, sha1, md5);
+        }
+
         QString fileHashToStringInternal(FileHash const& hash, QChar dash)
         {
             if (hash.isNull())
@@ -79,5 +145,13 @@ namespace PMP
         return "(" + QString::number(_length) + "; "
             + _sha1.toHex() + "; "
             + _md5.toHex() + ")";
+    }
+
+    FileHash FileHash::tryParse(const QString& text)
+    {
+        auto simplifiedText = text;
+        simplifiedText.replace(UnicodeChars::figureDash, '-');
+
+        return tryParseFileHashInternal(simplifiedText);
     }
 }

--- a/src/common/filehash.cpp
+++ b/src/common/filehash.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -25,6 +25,19 @@
 
 namespace PMP
 {
+    namespace
+    {
+        QString fileHashToStringInternal(FileHash const& hash, QChar dash)
+        {
+            if (hash.isNull())
+                return "(null)";
+
+            return QString::number(hash.length())
+                   + dash + hash.SHA1().toHex()
+                   + dash + hash.MD5().toHex();
+        }
+    }
+
     FileHash::FileHash(uint length, const QByteArray& sha1,
         const QByteArray& md5)
      : _length(length), _sha1(sha1), _md5(md5)
@@ -50,12 +63,12 @@ namespace PMP
     QString FileHash::toString() const
     {
         auto dash = '-';
-        return toStringInternal(dash);
+        return fileHashToStringInternal(*this, dash);
     }
 
     QString FileHash::toFancyString() const
     {
-        return toStringInternal(UnicodeChars::figureDash);
+        return fileHashToStringInternal(*this, UnicodeChars::figureDash);
     }
 
     QString FileHash::dumpToString() const
@@ -66,13 +79,5 @@ namespace PMP
         return "(" + QString::number(_length) + "; "
             + _sha1.toHex() + "; "
             + _md5.toHex() + ")";
-    }
-
-    QString FileHash::toStringInternal(QChar dash) const
-    {
-        if (isNull())
-            return "(null)";
-
-        return QString::number(_length) + dash + _sha1.toHex() + dash + _md5.toHex();
     }
 }

--- a/src/common/filehash.h
+++ b/src/common/filehash.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2021, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -50,8 +50,6 @@ namespace PMP
         QString dumpToString() const;
 
     private:
-        QString toStringInternal(QChar dash) const;
-
         uint _length;
         QByteArray _sha1;
         QByteArray _md5;

--- a/src/common/filehash.h
+++ b/src/common/filehash.h
@@ -49,6 +49,8 @@ namespace PMP
         QString toFancyString() const;
         QString dumpToString() const;
 
+        static FileHash tryParse(QString const& text);
+
     private:
         uint _length;
         QByteArray _sha1;

--- a/src/gui-remote/collectiontablemodel.cpp
+++ b/src/gui-remote/collectiontablemodel.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -916,7 +916,8 @@ namespace PMP
                                              ServerInterface* serverInterface,
                                              QueueHashesMonitor* queueHashesMonitor,
                                        UserForStatisticsDisplay* userForStatisticsDisplay)
-     : _source(source),
+     : _hashIdRepository(serverInterface->hashIdRepository()),
+       _source(source),
        _filteringTrackJudge(serverInterface->userDataFetcher(), *queueHashesMonitor)
     {
         Q_UNUSED(parent)
@@ -932,6 +933,12 @@ namespace PMP
                                            userForStatisticsDisplay->userId().valueOr(0));
                 invalidateFilter();
             }
+        );
+
+        auto& collectionWatcher = serverInterface->collectionWatcher();
+        connect(
+            &collectionWatcher, &CollectionWatcher::newTrackReceived,
+            this, &FilteredCollectionTableModel::onNewTrackReceived
         );
 
         setSourceModel(source);
@@ -961,7 +968,24 @@ namespace PMP
 
     void FilteredCollectionTableModel::setSearchText(QString search)
     {
-        _searchParts = search.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+        auto trimmed = search.trimmed();
+
+        auto fileHash = FileHash::tryParse(trimmed);
+        if (!fileHash.isNull())
+        {
+            auto hashId = _hashIdRepository->getId(fileHash); // zero id when not found
+
+            _searchParts.clear();
+            _searchFileHash = fileHash;
+            _searchHashId = hashId;
+        }
+        else
+        {
+            _searchParts = trimmed.split(QRegExp("\\s+"), Qt::SkipEmptyParts);
+            _searchFileHash = FileHash();
+            _searchHashId = null;
+        }
+
         invalidateFilter();
     }
 
@@ -970,7 +994,8 @@ namespace PMP
     {
         Q_UNUSED(sourceParent)
 
-        if (_searchParts.empty() && _filteringTrackJudge.criteriumResultsInAllTracks())
+        if (_searchParts.empty() && _searchHashId == null
+            && _filteringTrackJudge.criteriumResultsInAllTracks())
         {
             return true; /* not filtered */
         }
@@ -987,8 +1012,28 @@ namespace PMP
                     return false;
             }
         }
+        else if (_searchHashId != null)
+        {
+            if (track->hashId() != _searchHashId.value())
+                return false;
+        }
 
         return _filteringTrackJudge.trackSatisfiesCriteria(*track).isTrue();
     }
 
+    void FilteredCollectionTableModel::onNewTrackReceived(CollectionTrackInfo track)
+    {
+        /* See if we can finally get the LocalHashId of the FileHash that is used as the
+           search query */
+        if (_searchHashId != null && _searchHashId.value().isZero()
+            && !_searchFileHash.isNull())
+        {
+            auto fileHashOfNewTrack = _hashIdRepository->getHash(track.hashId());
+            if (fileHashOfNewTrack == _searchFileHash)
+            {
+                _searchHashId = track.hashId();
+                invalidateFilter();
+            }
+        }
+    }
 }

--- a/src/gui-remote/collectiontablemodel.h
+++ b/src/gui-remote/collectiontablemodel.h
@@ -175,7 +175,7 @@ namespace PMP
         void onNewTrackReceived(Client::CollectionTrackInfo track);
 
     private:
-        Client::LocalHashIdRepository* _hashIdRepository;
+        Client::ServerInterface* _serverInterface;
         SortedCollectionTableModel* _source;
         QStringList _searchParts;
         FileHash _searchFileHash;

--- a/src/gui-remote/collectiontablemodel.h
+++ b/src/gui-remote/collectiontablemodel.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2024, Kevin Andre <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,6 +20,8 @@
 #ifndef PMP_COLLECTIONTABLEMODEL_H
 #define PMP_COLLECTIONTABLEMODEL_H
 
+#include "common/filehash.h"
+#include "common/nullable.h"
 #include "common/playerstate.h"
 
 #include "client/collectiontrackinfo.h"
@@ -169,9 +171,15 @@ namespace PMP
     protected:
         bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
 
+    private Q_SLOTS:
+        void onNewTrackReceived(Client::CollectionTrackInfo track);
+
     private:
+        Client::LocalHashIdRepository* _hashIdRepository;
         SortedCollectionTableModel* _source;
         QStringList _searchParts;
+        FileHash _searchFileHash;
+        Nullable<Client::LocalHashId> _searchHashId;
         TrackJudge _filteringTrackJudge;
     };
 }

--- a/testing/test_sortedcollectiontablemodel.cpp
+++ b/testing/test_sortedcollectiontablemodel.cpp
@@ -563,6 +563,13 @@ Future<CollectionTrackInfo, AnyResultMessageCode> CollectionWatcherMock::getTrac
     NOT_IMPLEMENTED
 }
 
+Future<CollectionTrackInfo, AnyResultMessageCode> CollectionWatcherMock::getTrackInfo(
+                                                                    const FileHash& hash)
+{
+    Q_UNUSED(hash)
+    NOT_IMPLEMENTED
+}
+
 /* =========== */
 
 ServerInterfaceMock::ServerInterfaceMock()

--- a/testing/test_sortedcollectiontablemodel.h
+++ b/testing/test_sortedcollectiontablemodel.h
@@ -136,6 +136,8 @@ public:
     Nullable<CollectionTrackInfo> getTrackFromCache(LocalHashId hashId) override;
     Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
                                                              LocalHashId hashId) override;
+    Future<CollectionTrackInfo, AnyResultMessageCode> getTrackInfo(
+                                                        FileHash const& hash) override;
 
 private:
     QHash<LocalHashId, CollectionTrackInfo> _collection;


### PR DESCRIPTION
Pasting a track hash into the search field of the music collection will now search for the track with that particular hash. This is an exact search; pasting part of a hash will not work and will do a regular textual search instead.

Since a hash uniquely identifies a track, there will never be more than one result when searching by hash. There can be zero results if any of the following conditions is true:

 - one of the other filters excludes the track from the result
 - the server is not familiar (anymore) with the track
 - you are using a legacy hash value (an old alias of the real hash)

The hash of a track can be obtained using the "copy hash" button of the track info dialog or using the command-line hash tool.