### PR TITLE
Add version information to Windows executables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,10 +305,18 @@ target_link_libraries(PmpDesktopRemote Qt5::Core Qt5::Gui Qt5::Network Qt5::Widg
 add_library(PmpServer OBJECT ${PMP_SERVER_SOURCES} ${PMP_SERVER_MOCS})
 target_link_libraries(PmpServer Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
 
-add_executable(PMP-HashTool
+SET(PMP_HASHTOOL_TARGETNAME PMP-HashTool)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    configure_file(tools/hashtool-winres.rc.in tools/hashtool-winres.rc)
+    set(PMP_HASHTOOL_WIN32_RESOURCES tools/hashtool-winres.rc)
+endif()
+
+add_executable(${PMP_HASHTOOL_TARGETNAME}
+    ${PMP_HASHTOOL_WIN32_RESOURCES}
     tools/hash-main.cpp
 )
-target_link_libraries(PMP-HashTool
+target_link_libraries(${PMP_HASHTOOL_TARGETNAME}
     $<TARGET_OBJECTS:PmpCommon>
 )
 
@@ -321,49 +329,67 @@ target_link_libraries(quicktest
     $<TARGET_OBJECTS:PmpCommon>
 )
 
-add_executable(PMP-Server
+set(PMP_SERVER_TARGETNAME PMP-Server)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    configure_file(server/winres.rc.in server/winres.rc)
+    set(PMP_SERVER_WIN32_RESOURCES server/winres.rc)
+endif()
+
+add_executable(${PMP_SERVER_TARGETNAME}
+    ${PMP_SERVER_WIN32_RESOURCES}
     server/server-main.cpp
 )
-target_link_libraries(PMP-Server
+target_link_libraries(${PMP_SERVER_TARGETNAME}
     $<TARGET_OBJECTS:PmpServer>
     $<TARGET_OBJECTS:PmpCommon>
 )
 
-add_executable(PMP-Cmd-Remote
+set(PMP_CMD_REMOTE_TARGETNAME PMP-Cmd-Remote)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    configure_file(cmd-remote/winres.rc.in cmd-remote/winres.rc)
+    set(PMP_CMD_REMOTE_WIN32_RESOURCES cmd-remote/winres.rc)
+endif()
+
+add_executable(${PMP_CMD_REMOTE_TARGETNAME}
+    ${PMP_CMD_REMOTE_WIN32_RESOURCES}
     cmd-remote/cmd-remote-main.cpp
 )
-target_link_libraries(PMP-Cmd-Remote
+target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME}
     $<TARGET_OBJECTS:PmpCmdRemote>
     $<TARGET_OBJECTS:PmpClient>
     $<TARGET_OBJECTS:PmpCommon>
 )
+
+set(PMP_DESKTOP_REMOTE_TARGETNAME PMP-Desktop-Remote)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     configure_file(desktop-remote/winres.rc.in desktop-remote/winres.rc)
     set(PMP_DESKTOP_REMOTE_WIN32_RESOURCES desktop-remote/winres.rc)
 endif()
 
-add_executable(PMP-Desktop-Remote
+add_executable(${PMP_DESKTOP_REMOTE_TARGETNAME}
     ${PMP_WIN32_FLAG}
     ${PMP_DESKTOP_REMOTE_WIN32_RESOURCES}
     desktop-remote/desktop-remote-main.cpp
 )
-target_link_libraries(PMP-Desktop-Remote
+target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME}
     $<TARGET_OBJECTS:PmpDesktopRemote>
     $<TARGET_OBJECTS:PmpClient>
     $<TARGET_OBJECTS:PmpCommon>
 )
 
 # Qt dependencies for each executable
-target_link_libraries(PMP-HashTool Qt5::Core)
+target_link_libraries(${PMP_HASHTOOL_TARGETNAME} Qt5::Core)
 target_link_libraries(quicktest Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
-target_link_libraries(PMP-Server Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
-target_link_libraries(PMP-Cmd-Remote Qt5::Core Qt5::Network)
-target_link_libraries(PMP-Desktop-Remote Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets)
+target_link_libraries(${PMP_SERVER_TARGETNAME} Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
+target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME} Qt5::Core Qt5::Network)
+target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME} Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets)
 
 # Link executables to TagLib
-target_link_libraries(PMP-HashTool ${TAGLIB_LIBRARIES})
+target_link_libraries(${PMP_HASHTOOL_TARGETNAME} ${TAGLIB_LIBRARIES})
 target_link_libraries(quicktest ${TAGLIB_LIBRARIES})
-target_link_libraries(PMP-Server ${TAGLIB_LIBRARIES})
-target_link_libraries(PMP-Cmd-Remote ${TAGLIB_LIBRARIES})
-target_link_libraries(PMP-Desktop-Remote ${TAGLIB_LIBRARIES})
+target_link_libraries(${PMP_SERVER_TARGETNAME} ${TAGLIB_LIBRARIES})
+target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME} ${TAGLIB_LIBRARIES})
+target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME} ${TAGLIB_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -305,74 +305,63 @@ target_link_libraries(PmpDesktopRemote Qt5::Core Qt5::Gui Qt5::Network Qt5::Widg
 add_library(PmpServer OBJECT ${PMP_SERVER_SOURCES} ${PMP_SERVER_MOCS})
 target_link_libraries(PmpServer Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
 
-SET(PMP_HASHTOOL_TARGETNAME PMP-HashTool)
+set(PMP_HASHTOOL_TARGETNAME PMP-HashTool)
+set(PMP_QUICKTEST_TARGETNAME quicktest)
+set(PMP_SERVER_TARGETNAME PMP-Server)
+set(PMP_CMD_REMOTE_TARGETNAME PMP-Cmd-Remote)
+set(PMP_DESKTOP_REMOTE_TARGETNAME PMP-Desktop-Remote)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     configure_file(tools/hashtool-winres.rc.in tools/hashtool-winres.rc)
     set(PMP_HASHTOOL_WIN32_RESOURCES tools/hashtool-winres.rc)
+
+    configure_file(server/winres.rc.in server/winres.rc)
+    set(PMP_SERVER_WIN32_RESOURCES server/winres.rc)
+
+    configure_file(cmd-remote/winres.rc.in cmd-remote/winres.rc)
+    set(PMP_CMD_REMOTE_WIN32_RESOURCES cmd-remote/winres.rc)
+
+    configure_file(desktop-remote/winres.rc.in desktop-remote/winres.rc)
+    set(PMP_DESKTOP_REMOTE_WIN32_RESOURCES desktop-remote/winres.rc)
 endif()
 
 add_executable(${PMP_HASHTOOL_TARGETNAME}
     ${PMP_HASHTOOL_WIN32_RESOURCES}
     tools/hash-main.cpp
 )
-target_link_libraries(${PMP_HASHTOOL_TARGETNAME}
-    $<TARGET_OBJECTS:PmpCommon>
-)
-
-add_executable(quicktest
+add_executable(${PMP_QUICKTEST_TARGETNAME}
     tools/quicktest.cpp
 )
-target_link_libraries(quicktest
-    $<TARGET_OBJECTS:PmpServer>
-    $<TARGET_OBJECTS:PmpClient>
-    $<TARGET_OBJECTS:PmpCommon>
-)
-
-set(PMP_SERVER_TARGETNAME PMP-Server)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    configure_file(server/winres.rc.in server/winres.rc)
-    set(PMP_SERVER_WIN32_RESOURCES server/winres.rc)
-endif()
-
 add_executable(${PMP_SERVER_TARGETNAME}
     ${PMP_SERVER_WIN32_RESOURCES}
     server/server-main.cpp
+)
+add_executable(${PMP_CMD_REMOTE_TARGETNAME}
+    ${PMP_CMD_REMOTE_WIN32_RESOURCES}
+    cmd-remote/cmd-remote-main.cpp
+)
+add_executable(${PMP_DESKTOP_REMOTE_TARGETNAME}
+    ${PMP_WIN32_FLAG}
+    ${PMP_DESKTOP_REMOTE_WIN32_RESOURCES}
+    desktop-remote/desktop-remote-main.cpp
+)
+
+target_link_libraries(${PMP_HASHTOOL_TARGETNAME}
+    $<TARGET_OBJECTS:PmpCommon>
+)
+target_link_libraries(${PMP_QUICKTEST_TARGETNAME}
+    $<TARGET_OBJECTS:PmpServer>
+    $<TARGET_OBJECTS:PmpClient>
+    $<TARGET_OBJECTS:PmpCommon>
 )
 target_link_libraries(${PMP_SERVER_TARGETNAME}
     $<TARGET_OBJECTS:PmpServer>
     $<TARGET_OBJECTS:PmpCommon>
 )
-
-set(PMP_CMD_REMOTE_TARGETNAME PMP-Cmd-Remote)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    configure_file(cmd-remote/winres.rc.in cmd-remote/winres.rc)
-    set(PMP_CMD_REMOTE_WIN32_RESOURCES cmd-remote/winres.rc)
-endif()
-
-add_executable(${PMP_CMD_REMOTE_TARGETNAME}
-    ${PMP_CMD_REMOTE_WIN32_RESOURCES}
-    cmd-remote/cmd-remote-main.cpp
-)
 target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME}
     $<TARGET_OBJECTS:PmpCmdRemote>
     $<TARGET_OBJECTS:PmpClient>
     $<TARGET_OBJECTS:PmpCommon>
-)
-
-set(PMP_DESKTOP_REMOTE_TARGETNAME PMP-Desktop-Remote)
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    configure_file(desktop-remote/winres.rc.in desktop-remote/winres.rc)
-    set(PMP_DESKTOP_REMOTE_WIN32_RESOURCES desktop-remote/winres.rc)
-endif()
-
-add_executable(${PMP_DESKTOP_REMOTE_TARGETNAME}
-    ${PMP_WIN32_FLAG}
-    ${PMP_DESKTOP_REMOTE_WIN32_RESOURCES}
-    desktop-remote/desktop-remote-main.cpp
 )
 target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME}
     $<TARGET_OBJECTS:PmpDesktopRemote>
@@ -381,15 +370,37 @@ target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME}
 )
 
 # Qt dependencies for each executable
-target_link_libraries(${PMP_HASHTOOL_TARGETNAME} Qt5::Core)
-target_link_libraries(quicktest Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
-target_link_libraries(${PMP_SERVER_TARGETNAME} Qt5::Core Qt5::Multimedia Qt5::Network Qt5::Sql Qt5::Xml)
-target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME} Qt5::Core Qt5::Network)
-target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME} Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets)
+target_link_libraries(${PMP_HASHTOOL_TARGETNAME}
+    Qt5::Core
+)
+target_link_libraries(${PMP_QUICKTEST_TARGETNAME}
+    Qt5::Core
+    Qt5::Multimedia
+    Qt5::Network
+    Qt5::Sql
+    Qt5::Xml
+)
+target_link_libraries(${PMP_SERVER_TARGETNAME}
+    Qt5::Core
+    Qt5::Multimedia
+    Qt5::Network
+    Qt5::Sql
+    Qt5::Xml
+)
+target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME}
+    Qt5::Core
+    Qt5::Network
+)
+target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME}
+    Qt5::Core
+    Qt5::Gui
+    Qt5::Network
+    Qt5::Widgets
+)
 
 # Link executables to TagLib
 target_link_libraries(${PMP_HASHTOOL_TARGETNAME} ${TAGLIB_LIBRARIES})
-target_link_libraries(quicktest ${TAGLIB_LIBRARIES})
+target_link_libraries(${PMP_QUICKTEST_TARGETNAME} ${TAGLIB_LIBRARIES})
 target_link_libraries(${PMP_SERVER_TARGETNAME} ${TAGLIB_LIBRARIES})
 target_link_libraries(${PMP_CMD_REMOTE_TARGETNAME} ${TAGLIB_LIBRARIES})
 target_link_libraries(${PMP_DESKTOP_REMOTE_TARGETNAME} ${TAGLIB_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -339,14 +339,14 @@ target_link_libraries(PMP-Cmd-Remote
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-    set (PMP_DESKTOP_REMOTE_WIN32_RESOURCES desktop-remote/winres.rc)
+    configure_file(desktop-remote/winres.rc.in desktop-remote/winres.rc)
+    set(PMP_DESKTOP_REMOTE_WIN32_RESOURCES desktop-remote/winres.rc)
 endif()
 
 add_executable(PMP-Desktop-Remote
     ${PMP_WIN32_FLAG}
     ${PMP_DESKTOP_REMOTE_WIN32_RESOURCES}
     desktop-remote/desktop-remote-main.cpp
-
 )
 target_link_libraries(PMP-Desktop-Remote
     $<TARGET_OBJECTS:PmpDesktopRemote>

--- a/src/cmd-remote/winres.rc.in
+++ b/src/cmd-remote/winres.rc.in
@@ -1,7 +1,5 @@
 #include "windows.h"
 
-IDI_ICON1    ICON    "${CMAKE_CURRENT_SOURCE_DIR}/app-icon/app-icon.ico"
-
 VS_VERSION_INFO   VERSIONINFO
 FILEVERSION       ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
 PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
@@ -11,10 +9,10 @@ PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
         BLOCK "040904B0"
         {
             VALUE "CompanyName",        "${PMP_ORGANIZATION_NAME}"
-            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Command-line Remote"
             VALUE "FileVersion",        "${PMP_VERSION_DISPLAY}"
-            VALUE "OriginalFilename",   "${PMP_DESKTOP_REMOTE_TARGETNAME}.exe"
-            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "OriginalFilename",   "${PMP_CMD_REMOTE_TARGETNAME}.exe"
+            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Command-line Remote"
             VALUE "ProductVersion",     "${PMP_VERSION_DISPLAY}"
         }
     }

--- a/src/desktop-remote/winres.rc
+++ b/src/desktop-remote/winres.rc
@@ -1,1 +1,0 @@
-IDI_ICON1               ICON    "../app-icon/app-icon.ico"

--- a/src/desktop-remote/winres.rc.in
+++ b/src/desktop-remote/winres.rc.in
@@ -1,0 +1,25 @@
+#include "windows.h"
+
+IDI_ICON1    ICON    "${CMAKE_CURRENT_SOURCE_DIR}/app-icon/app-icon.ico"
+
+VS_VERSION_INFO   VERSIONINFO
+FILEVERSION       ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
+PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
+{
+    BLOCK "StringFileInfo"
+    {
+        BLOCK "040904B0"
+        {
+            VALUE "CompanyName",        "${PMP_ORGANIZATION_NAME}"
+            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "FileVersion",        "${PMP_VERSION_DISPLAY}"
+            VALUE "OriginalFilename",   "PMP-Desktop-Remote.exe"
+            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "ProductVersion",     "${PMP_VERSION_DISPLAY}"
+        }
+    }
+    BLOCK "VarFileInfo"
+    {
+        VALUE "Translation", 0x0409, 1200
+    }
+}

--- a/src/server/winres.rc.in
+++ b/src/server/winres.rc.in
@@ -1,7 +1,5 @@
 #include "windows.h"
 
-IDI_ICON1    ICON    "${CMAKE_CURRENT_SOURCE_DIR}/app-icon/app-icon.ico"
-
 VS_VERSION_INFO   VERSIONINFO
 FILEVERSION       ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
 PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
@@ -11,10 +9,10 @@ PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
         BLOCK "040904B0"
         {
             VALUE "CompanyName",        "${PMP_ORGANIZATION_NAME}"
-            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Server"
             VALUE "FileVersion",        "${PMP_VERSION_DISPLAY}"
-            VALUE "OriginalFilename",   "${PMP_DESKTOP_REMOTE_TARGETNAME}.exe"
-            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "OriginalFilename",   "${PMP_SERVER_TARGETNAME}.exe"
+            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Server"
             VALUE "ProductVersion",     "${PMP_VERSION_DISPLAY}"
         }
     }

--- a/src/tools/hashtool-winres.rc.in
+++ b/src/tools/hashtool-winres.rc.in
@@ -1,7 +1,5 @@
 #include "windows.h"
 
-IDI_ICON1    ICON    "${CMAKE_CURRENT_SOURCE_DIR}/app-icon/app-icon.ico"
-
 VS_VERSION_INFO   VERSIONINFO
 FILEVERSION       ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
 PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
@@ -11,10 +9,10 @@ PRODUCTVERSION    ${PMP_VERSION_MAJOR},${PMP_VERSION_MINOR},${PMP_VERSION_PATCH}
         BLOCK "040904B0"
         {
             VALUE "CompanyName",        "${PMP_ORGANIZATION_NAME}"
-            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "FileDescription",    "${PMP_PRODUCT_NAME} - Hash Tool"
             VALUE "FileVersion",        "${PMP_VERSION_DISPLAY}"
-            VALUE "OriginalFilename",   "${PMP_DESKTOP_REMOTE_TARGETNAME}.exe"
-            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Desktop Remote"
+            VALUE "OriginalFilename",   "${PMP_HASHTOOL_TARGETNAME}.exe"
+            VALUE "ProductName",        "${PMP_PRODUCT_NAME} - Hash Tool"
             VALUE "ProductVersion",     "${PMP_VERSION_DISPLAY}"
         }
     }


### PR DESCRIPTION
Use VERSIONINFO in Windows resource scripts to add version information to the executables for Windows platforms. This is the information displayed by Windows Explorer in tooltips and when viewing file properties.