### PR TITLE
Track info dialog: put track title and artist in window title

### DIFF
--- a/maintenance/TODOs.txt
+++ b/maintenance/TODOs.txt
@@ -103,7 +103,6 @@ IDEAS
  * track info dialog: display filename(s)
  * track info dialog: should become modeless
  * track info dialog: last heard: display "almost 3 months" ago instead of "2 months ago" when applicable
- * track info dialog: put track title/artist in dialog title
  * compatibility UI: let older clients know what's going on (status message) and offer them some limited control (actions)
  * server database backup and restore
  * command-line remote: add a command for seeking (going to a specific time in the current track)

--- a/src/desktop-remote/trackinfodialog.cpp
+++ b/src/desktop-remote/trackinfodialog.cpp
@@ -380,6 +380,24 @@ namespace PMP
 
     void TrackInfoDialog::fillTrackDetails(const CollectionTrackInfo& trackInfo)
     {
+        QString trackTitleForWindowTitle = trackInfo.title().trimmed();
+        QString trackArtistForWindowTitle = trackInfo.artist().trimmed();
+
+        if (trackTitleForWindowTitle.isEmpty())
+        {
+            trackTitleForWindowTitle = tr("(no title)");
+        }
+        if (trackArtistForWindowTitle.isEmpty())
+        {
+            trackArtistForWindowTitle = tr("(no artist)");
+        }
+
+        setWindowTitle(tr("Track Info %1 %2 %3 %4")
+                           .arg(UnicodeChars::emDash)
+                           .arg(trackTitleForWindowTitle)
+                           .arg(UnicodeChars::enDash)
+                           .arg(trackArtistForWindowTitle));
+
         _ui->titleValueLabel->setText(trackInfo.title());
         _ui->artistValueLabel->setText(trackInfo.artist());
         _ui->albumValueLabel->setText(trackInfo.album());
@@ -453,6 +471,8 @@ namespace PMP
 
     void TrackInfoDialog::clearTrackDetails()
     {
+        setWindowTitle(tr("Track Info"));
+
         _ui->titleValueLabel->clear();
         _ui->artistValueLabel->clear();
         _ui->albumValueLabel->clear();


### PR DESCRIPTION
In the track info dialog, add title and artist of the track to the window title of the dialog.