### PR TITLE
Start using server-side track IDs in client-server communication

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(PMP_CLIENT_SOURCES
     client/serverconnection.cpp
     client/serverdiscoverer.cpp
     client/serverinterface.cpp
+    client/trackserveridrepository.cpp
     client/userdatafetcher.cpp
     client/volumemediator.cpp
 )

--- a/src/client/queuecontroller.h
+++ b/src/client/queuecontroller.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -26,6 +26,7 @@
 #include "common/specialqueueitemtype.h"
 
 #include "client/localhashid.h"
+#include "client/trackhashorid.h"
 
 #include <QObject>
 
@@ -44,8 +45,11 @@ namespace PMP::Client
     public Q_SLOTS:
         virtual void insertBreakAtFrontIfNotExists() = 0;
         virtual void insertQueueEntryAtFront(LocalHashId hashId) = 0;
+        virtual void insertQueueEntryAtFront(TrackHashOrId track) = 0;
         virtual void insertQueueEntryAtEnd(LocalHashId hashId) = 0;
+        virtual void insertQueueEntryAtEnd(TrackHashOrId track) = 0;
         virtual RequestID insertQueueEntryAtIndex(LocalHashId hashId, quint32 index) = 0;
+        virtual RequestID insertQueueEntryAtIndex(TrackHashOrId track, quint32 index) = 0;
         virtual RequestID insertSpecialItemAtIndex(SpecialQueueItemType itemType,
                                                    int index,
                                    QueueIndexType indexType = QueueIndexType::Normal) = 0;

--- a/src/client/queuecontrollerimpl.cpp
+++ b/src/client/queuecontrollerimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -84,15 +84,31 @@ namespace PMP::Client
         _connection->insertQueueEntryAtFront(hashId);
     }
 
+    void QueueControllerImpl::insertQueueEntryAtFront(TrackHashOrId track)
+    {
+        _connection->insertQueueEntryAtFront(track);
+    }
+
     void QueueControllerImpl::insertQueueEntryAtEnd(LocalHashId hashId)
     {
         _connection->insertQueueEntryAtEnd(hashId);
+    }
+
+    void QueueControllerImpl::insertQueueEntryAtEnd(TrackHashOrId track)
+    {
+        _connection->insertQueueEntryAtEnd(track);
     }
 
     RequestID QueueControllerImpl::insertQueueEntryAtIndex(LocalHashId hashId,
                                                            quint32 index)
     {
         return _connection->insertQueueEntryAtIndex(hashId, index);
+    }
+
+    RequestID QueueControllerImpl::insertQueueEntryAtIndex(TrackHashOrId track,
+                                                           quint32 index)
+    {
+        return _connection->insertQueueEntryAtIndex(track, index);
     }
 
     RequestID QueueControllerImpl::insertSpecialItemAtIndex(SpecialQueueItemType itemType,

--- a/src/client/queuecontrollerimpl.h
+++ b/src/client/queuecontrollerimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -39,8 +39,11 @@ namespace PMP::Client
     public Q_SLOTS:
         void insertBreakAtFrontIfNotExists() override;
         void insertQueueEntryAtFront(LocalHashId hashId) override;
+        void insertQueueEntryAtFront(TrackHashOrId track) override;
         void insertQueueEntryAtEnd(LocalHashId hashId) override;
+        void insertQueueEntryAtEnd(TrackHashOrId track) override;
         RequestID insertQueueEntryAtIndex(LocalHashId hashId, quint32 index) override;
+        RequestID insertQueueEntryAtIndex(TrackHashOrId track, quint32 index) override;
         RequestID insertSpecialItemAtIndex(SpecialQueueItemType itemType, int index,
                                            QueueIndexType indexType) override;
         void deleteQueueEntry(uint queueId) override;

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -716,7 +716,7 @@ namespace PMP::Client
 
     /* ============================================================================ */
 
-    const quint16 ServerConnection::ClientProtocolNo = 27;
+    const quint16 ServerConnection::ClientProtocolNo = 28;
 
     const int ServerConnection::KeepAliveIntervalMs = 30 * 1000;
     const int ServerConnection::KeepAliveReplyTimeoutMs = 5 * 1000;
@@ -3694,24 +3694,37 @@ namespace PMP::Client
 
     void ServerConnection::parseHashInfoReply(const QByteArray& message)
     {
-        if (message.length() < 20)
+        bool includesTrackId = _serverProtocolNo >= 28;
+
+        if (message.length() < (20 + (includesTrackId ? 8 : 0)))
             return; /* invalid message */
 
         quint8 availabilityByte = NetworkUtil::getByte(message, 3);
         quint32 clientReference = NetworkUtil::get4Bytes(message, 4);
-        int titleDataSize = NetworkUtil::get2BytesUnsignedToInt(message, 8);
-        int artistDataSize = NetworkUtil::get2BytesUnsignedToInt(message, 10);
-        int albumDataSize = NetworkUtil::get2BytesUnsignedToInt(message, 12);
-        int albumArtistDataSize = NetworkUtil::get2BytesUnsignedToInt(message, 14);
-        qint32 lengthInMilliseconds = NetworkUtil::get4BytesSigned(message, 16);
+
+        int offset = 8;
+
+        quint64 serverTrackId = 0;
+        if (includesTrackId)
+        {
+            serverTrackId = NetworkUtil::get8Bytes(message, offset);
+            offset += 8;
+        }
+
+        int titleDataSize = NetworkUtil::get2BytesUnsignedToInt(message, offset);
+        int artistDataSize = NetworkUtil::get2BytesUnsignedToInt(message, offset + 2);
+        int albumDataSize = NetworkUtil::get2BytesUnsignedToInt(message, offset + 4);
+        int albumArtistDataSize = NetworkUtil::get2BytesUnsignedToInt(message,offset + 6);
+        qint32 lengthInMilliseconds = NetworkUtil::get4BytesSigned(message, offset + 8);
+
+        offset += 4 * 2 + 4;
 
         const int expectedMessageLength =
-            20 + titleDataSize + artistDataSize + albumDataSize + albumArtistDataSize;
+            offset + titleDataSize + artistDataSize + albumDataSize + albumArtistDataSize;
 
         if (message.length() != expectedMessageLength)
             return;
 
-        int offset = 20;
         QString title = NetworkUtil::getUtf8String(message, offset, titleDataSize);
         offset += titleDataSize;
         QString artist = NetworkUtil::getUtf8String(message, offset, artistDataSize);
@@ -3724,6 +3737,7 @@ namespace PMP::Client
         bool isAvailable = availabilityByte & 1;
 
         qDebug() << "received hash info reply: ref:" << clientReference
+                 << "; server track id:" << serverTrackId
                  << "; title:" << title
                  << "; artist:" << artist
                  << "; album:" << album

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -3466,9 +3466,11 @@ namespace PMP::Client
 
         bool withAlbumAndTrackLength = _serverProtocolNo >= 7;
         bool withAlbumArtist = _serverProtocolNo >= 24;
+        bool withTrackId = _serverProtocolNo >= 28;
 
         const int fixedInfoLengthPerTrack =
-            NetworkProtocol::FILEHASH_BYTECOUNT + 1 + 2 + 2
+                (withTrackId ? 8 : 0)
+                + NetworkProtocol::FILEHASH_BYTECOUNT + 1 + 2 + 2
                 + (withAlbumAndTrackLength ? 2 + 4 : 0)
                 + (withAlbumArtist ? 2 : 0);
 
@@ -3490,8 +3492,9 @@ namespace PMP::Client
 
         while (true)
         {
-            /* set pointer past hash and availability */
-            int current = offset + NetworkProtocol::FILEHASH_BYTECOUNT + 1;
+            /* set pointer past track ID and hash and availability */
+            int current =
+                offset + (withTrackId ? 8 : 0) + NetworkProtocol::FILEHASH_BYTECOUNT + 1;
             int titleSize = NetworkUtil::get2BytesUnsignedToInt(message, current);
             current += 2;
             int artistSize = NetworkUtil::get2BytesUnsignedToInt(message, current);
@@ -3557,6 +3560,13 @@ namespace PMP::Client
         for (int i = 0; i < trackCount; ++i)
         {
             offset = offsets[i];
+
+            quint64 trackId = 0;
+            if (withTrackId)
+            {
+                trackId = NetworkUtil::get8Bytes(message, offset);
+                offset += 8;
+            }
 
             bool ok;
             FileHash hash = NetworkProtocol::getHash(message, offset, &ok);

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -28,6 +28,7 @@
 #include "collectionfetcher.h"
 #include "localhashidrepository.h"
 #include "servercapabilitiesimpl.h"
+#include "trackserveridrepository.h"
 
 #include <QtDebug>
 #include <QTimer>
@@ -164,9 +165,10 @@ namespace PMP::Client
         virtual void handleHistoryFragment(quint32 clientReference,
                                            HistoryFragment fragment);
 
-        virtual void handleHashInfo(quint32 clientReference, bool isAvailable,
-                                    QString title, QString artist, QString album,
-                                    QString albumArtist, qint32 lengthInMilliseconds);
+        virtual void handleHashInfo(quint32 clientReference, quint64 trackServerId,
+                                    bool isAvailable, QString title, QString artist,
+                                    QString album, QString albumArtist,
+                                    qint32 lengthInMilliseconds);
 
     protected:
         ResultHandler(ServerConnection* parent);
@@ -221,6 +223,7 @@ namespace PMP::Client
     }
 
     void ServerConnection::ResultHandler::handleHashInfo(quint32 clientReference,
+                                                         quint64 trackServerId,
                                                          bool isAvailable, QString title,
                                                          QString artist, QString album,
                                                          QString albumArtist,
@@ -232,6 +235,7 @@ namespace PMP::Client
 
         qWarning() << "ResultHandler does not handle hash info;"
                    << " ref:" << clientReference
+                   << " track server ID:" << trackServerId
                    << " title:" << title << " artist:" << artist << " album:" << album;
     }
 
@@ -665,8 +669,9 @@ namespace PMP::Client
 
         void handleResult(ResultMessageData const& data) override;
 
-        void handleHashInfo(quint32 clientReference, bool isAvailable, QString title,
-                            QString artist, QString album, QString albumArtist,
+        void handleHashInfo(quint32 clientReference, quint64 trackServerId,
+                            bool isAvailable, QString title, QString artist,
+                            QString album, QString albumArtist,
                             qint32 lengthInMilliseconds) override;
 
     private:
@@ -697,6 +702,7 @@ namespace PMP::Client
     }
 
     void ServerConnection::HashInfoResultHandler::handleHashInfo(quint32 clientReference,
+                                                                 quint64 trackServerId,
                                                                  bool isAvailable,
                                                                  QString title,
                                                                  QString artist,
@@ -707,6 +713,9 @@ namespace PMP::Client
         Q_UNUSED(clientReference)
 
         auto hashId = _parent->_hashIdRepository->getOrRegisterId(_hash);
+
+        if (trackServerId > 0)
+            _parent->_trackServerIdRepository->registerHashWithId(_hash, trackServerId);
 
         CollectionTrackInfo trackInfo(hashId, isAvailable, title, artist, album,
                                       albumArtist, lengthInMilliseconds);
@@ -723,9 +732,11 @@ namespace PMP::Client
 
     ServerConnection::ServerConnection(QObject* parent,
                                        LocalHashIdRepository* hashIdRepository,
+                                       TrackServerIdRepository *trackServerIdRepository,
                                        ServerEventSubscription eventSubscription)
      : QObject(parent),
        _hashIdRepository(hashIdRepository),
+       _trackServerIdRepository(trackServerIdRepository),
        _serverCapabilities(new ServerCapabilitiesImpl()),
        _disconnectReason(DisconnectReason::Unknown),
        _inactivityTimer(new InactivityTimer(this)),
@@ -1251,12 +1262,38 @@ namespace PMP::Client
     {
         auto hash = _hashIdRepository->getHash(hashId);
 
+        insertQueueEntryAtFront(TrackHashOrId(hash));
+    }
+
+    void ServerConnection::insertQueueEntryAtFront(TrackHashOrId track)
+    {
+        Q_ASSERT_X(
+            !track.isNull(),
+            "ServerConnection::insertQueueEntryAtFront(TrackHashOrId)",
+            "track is null");
+
+        replaceTrackHashWithServerIdIfPossible(track);
+
+        bool withId = track.isId();
+
+        Q_ASSERT_X(
+            !withId || _serverProtocolNo >= 28,
+            "ServerConnection::insertQueueEntryAtFront(TrackHashOrId)",
+            "server is too old to support insertion by track ID");
+
+        qDebug() << "sending request to insert track" << track
+                 << "into the queue at the front";
+
         QByteArray message;
-        message.reserve(2 + 2 + NetworkProtocol::FILEHASH_BYTECOUNT);
+        message.reserve(2 + 2 + (withId ? 8 : NetworkProtocol::FILEHASH_BYTECOUNT));
         NetworkProtocol::append2Bytes(message,
-                                  ClientMessageType::AddHashToFrontOfQueueRequestMessage);
+                                      ClientMessageType::AddHashToFrontOfQueueRequestMessage);
         NetworkUtil::append2Bytes(message, 0); /* filler */
-        NetworkProtocol::appendHash(message, hash);
+
+        if (withId)
+            NetworkUtil::append8Bytes(message, track.toId().value());
+        else
+            NetworkProtocol::appendHash(message, track.toHash().value());
 
         sendBinaryMessage(message);
     }
@@ -1265,12 +1302,38 @@ namespace PMP::Client
     {
         auto hash = _hashIdRepository->getHash(hashId);
 
+        insertQueueEntryAtEnd(TrackHashOrId(hash));
+    }
+
+    void ServerConnection::insertQueueEntryAtEnd(TrackHashOrId track)
+    {
+        Q_ASSERT_X(
+            !track.isNull(),
+            "ServerConnection::insertQueueEntryAtEnd(TrackHashOrId)",
+            "track is null");
+
+        replaceTrackHashWithServerIdIfPossible(track);
+
+        bool withId = track.isId();
+
+        Q_ASSERT_X(
+            !withId || _serverProtocolNo >= 28,
+            "ServerConnection::insertQueueEntryAtEnd(TrackHashOrId)",
+            "server is too old to support insertion by track ID");
+
+        qDebug() << "sending request to insert track" << track
+                 << "into the queue at the end";
+
         QByteArray message;
-        message.reserve(2 + 2 + NetworkProtocol::FILEHASH_BYTECOUNT);
+        message.reserve(2 + 2 + (withId ? 8 : NetworkProtocol::FILEHASH_BYTECOUNT));
         NetworkProtocol::append2Bytes(message,
-                                    ClientMessageType::AddHashToEndOfQueueRequestMessage);
+                                      ClientMessageType::AddHashToEndOfQueueRequestMessage);
         NetworkUtil::append2Bytes(message, 0); /* filler */
-        NetworkProtocol::appendHash(message, hash);
+
+        if (withId)
+            NetworkUtil::append8Bytes(message, track.toId().value());
+        else
+            NetworkProtocol::appendHash(message, track.toHash().value());
 
         sendBinaryMessage(message);
     }
@@ -1422,19 +1485,44 @@ namespace PMP::Client
 
         auto hash = _hashIdRepository->getHash(hashId);
 
+        return insertQueueEntryAtIndex(TrackHashOrId(hash), index);
+    }
+
+    RequestID ServerConnection::insertQueueEntryAtIndex(TrackHashOrId track,
+                                                        quint32 index)
+    {
+        if (track.isNull())
+            return signalRequestError(ResultMessageErrorCode::InvalidHash,
+                                      &ServerConnection::queueEntryInsertionFailed);
+
+        replaceTrackHashWithServerIdIfPossible(track);
+
+        /* check if the server accepts IDs if it is an ID */
+        if (track.isId() && _serverProtocolNo < 28)
+            return signalRequestError(ResultMessageErrorCode::ServerTooOld,
+                                      &ServerConnection::queueEntryInsertionFailed);
+
         auto handler = QSharedPointer<TrackInsertionResultHandler>::create(this, index);
         auto ref = registerResultHandler(handler);
 
-        qDebug() << "sending request to add a track at index" << index << "; ref=" << ref;
+        qDebug() << "sending request to insert track" << track
+                 << "into the queue at index" << index << "; ref=" << ref;
+
+        bool withId = track.isId();
 
         QByteArray message;
-        message.reserve(2 + 2 + 4 + 4 + NetworkProtocol::FILEHASH_BYTECOUNT);
+        message.reserve(2 + 2 + 4 + 4
+                        + (withId ? 8 : NetworkProtocol::FILEHASH_BYTECOUNT));
         NetworkProtocol::append2Bytes(message,
                                     ClientMessageType::InsertHashIntoQueueRequestMessage);
         NetworkUtil::append2Bytes(message, 0); /* filler */
         NetworkUtil::append4Bytes(message, ref);
         NetworkUtil::append4Bytes(message, index);
-        NetworkProtocol::appendHash(message, hash);
+
+        if (withId)
+            NetworkUtil::append8Bytes(message, track.toId().value());
+        else
+            NetworkProtocol::appendHash(message, track.toHash().value());
 
         sendBinaryMessage(message);
 
@@ -3202,7 +3290,12 @@ namespace PMP::Client
 
             LocalHashId hashId;
             if (hash.isNull() == false)
+            {
                 hashId = _hashIdRepository->getOrRegisterId(hash);
+
+                if (trackId > 0)
+                    _trackServerIdRepository->registerHashWithId(hash, trackId);
+            }
 
             Q_EMIT receivedQueueEntryHash(queueId, type, hashId);
         }
@@ -3619,6 +3712,9 @@ namespace PMP::Client
 
             auto hashId = _hashIdRepository->getOrRegisterId(hash);
 
+            if (trackId > 0)
+                _trackServerIdRepository->registerHashWithId(hash, trackId);
+
             CollectionTrackInfo info(hashId, availabilityByte & 1, title, artist, album,
                                      albumArtist, trackLengthInMs);
             infos.append(info);
@@ -3784,8 +3880,9 @@ namespace PMP::Client
         auto handler = _resultHandlers.take(clientReference);
         if (handler)
         {
-            handler->handleHashInfo(clientReference, isAvailable, title, artist,
-                                    album, albumArtist, lengthInMilliseconds);
+            handler->handleHashInfo(clientReference, serverTrackId, isAvailable,
+                                    title, artist, album, albumArtist,
+                                    lengthInMilliseconds);
         }
     }
 
@@ -3844,6 +3941,9 @@ namespace PMP::Client
 
             auto hashId = _hashIdRepository->getOrRegisterId(hash);
             bool validForScoring = status & 1;
+
+            if (trackId > 0)
+                _trackServerIdRepository->registerHashWithId(hash, trackId);
 
             qDebug() << "history entry: user" << userId << " track ID" << trackId
                      << " hash" << hash << " started" << started;
@@ -4087,5 +4187,41 @@ namespace PMP::Client
         }
 
         qDebug() << "received unknown server event:" << static_cast<int>(eventCode);
+    }
+
+    void ServerConnection::replaceTrackHashWithServerIdIfPossible(TrackHashOrId& track)
+    {
+        if (_serverProtocolNo >= 28)
+        {
+            /* server supports communication about track IDs */
+
+            if (!track.isHash())
+                return; /* nothing to replace */
+
+            auto idOrNull =
+                _trackServerIdRepository->getServerIdForHash(track.toHash().value());
+
+            if (idOrNull.isNull())
+                return; /* we don't have the ID */
+
+            /* we have the ID */
+            track = idOrNull.value();
+        }
+        else
+        {
+            /* server does not support communication about track IDs */
+
+            if (!track.isId())
+                return; /* nothing to replace */
+
+            auto hashOrNull =
+                _trackServerIdRepository->getHashForServerId(track.toId().value());
+
+            if (hashOrNull.isNull())
+                return; /* we don't have the hash */
+
+            /* we have the hash */
+            track = hashOrNull.value();
+        }
     }
 }

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -3137,6 +3137,8 @@ namespace PMP::Client
 
     void ServerConnection::parseBulkQueueEntryHashMessage(const QByteArray& message)
     {
+        bool withTrackId = _serverProtocolNo >= 28;
+
         qint32 messageLength = message.length();
         if (messageLength < 4)
         {
@@ -3145,9 +3147,12 @@ namespace PMP::Client
         }
 
         int trackCount = NetworkUtil::get2BytesUnsignedToInt(message, 2);
-        if (trackCount == 0
-            || messageLength
-                != 4 + trackCount * (8 + NetworkProtocol::FILEHASH_BYTECOUNT))
+        int expectedMessageLength =
+            4 + trackCount * (8
+                                + (withTrackId ? 8 : 0)
+                                + NetworkProtocol::FILEHASH_BYTECOUNT);
+
+        if (trackCount == 0 || messageLength != expectedMessageLength)
         {
             invalidMessageReceived(
                 message, "bulk-queue-entry-hashes",
@@ -3161,18 +3166,36 @@ namespace PMP::Client
         int offset = 4;
         for (int i = 0; i < trackCount; ++i)
         {
-            quint32 queueID = NetworkUtil::get4Bytes(message, offset);
+            quint32 queueId = NetworkUtil::get4Bytes(message, offset);
             quint16 status = NetworkUtil::get2Bytes(message, offset + 4);
             offset += 8;
+
+            quint64 trackId = 0;
+            if (withTrackId)
+            {
+                trackId = NetworkUtil::get8Bytes(message, offset);
+                offset += 8;
+            }
 
             bool ok;
             FileHash hash = NetworkProtocol::getHash(message, offset, &ok);
             offset += NetworkProtocol::FILEHASH_BYTECOUNT;
             if (!ok)
             {
-                qWarning() << "could not extract hash for QID" << queueID
+                qWarning() << "could not extract hash for QID" << queueId
                            << "; track status=" << status;
                 continue;
+            }
+
+            if (withTrackId)
+            {
+                qDebug() << "queue entry" << queueId << "has status" << status
+                         << "and track ID" << trackId << "and hash" << hash;
+            }
+            else
+            {
+                qDebug() << "queue entry" << queueId << "has status" << status
+                         << "and hash" << hash;
             }
 
             auto type = NetworkProtocol::trackStatusToQueueEntryType(status);
@@ -3181,7 +3204,7 @@ namespace PMP::Client
             if (hash.isNull() == false)
                 hashId = _hashIdRepository->getOrRegisterId(hash);
 
-            Q_EMIT receivedQueueEntryHash(queueID, type, hashId);
+            Q_EMIT receivedQueueEntryHash(queueId, type, hashId);
         }
     }
 

--- a/src/client/serverconnection.cpp
+++ b/src/client/serverconnection.cpp
@@ -3794,12 +3794,16 @@ namespace PMP::Client
         if (message.length() < 8)
             return; /* invalid message */
 
+        bool withTrackId = _serverProtocolNo >= 28;
+
         quint16 entryCount = NetworkUtil::get2BytesUnsignedToInt(message, 2);
         quint32 clientReference = NetworkUtil::get4Bytes(message, 4);
         uint nextStartId = NetworkUtil::get4Bytes(message, 8);
 
         auto expectedMessageSize =
-            12 + entryCount * (24 + NetworkProtocol::FILEHASH_BYTECOUNT);
+            12 + entryCount * (24
+                                + (withTrackId ? 8 : 0)
+                                + NetworkProtocol::FILEHASH_BYTECOUNT);
 
         if (message.length() != expectedMessageSize)
             return; /* invalid message */
@@ -3814,13 +3818,22 @@ namespace PMP::Client
         for (int i = 0; i < entryCount; ++i)
         {
             quint32 userId = NetworkUtil::get4Bytes(message, offset);
+            offset += 4;
+
+            quint64 trackId = 0;
+            if (withTrackId)
+            {
+                trackId = NetworkUtil::get8Bytes(message, offset);
+                offset += 8;
+            }
+
             QDateTime started =
-                NetworkUtil::getQDateTimeFrom8ByteMsSinceEpoch(message, offset + 4);
+                NetworkUtil::getQDateTimeFrom8ByteMsSinceEpoch(message, offset);
             QDateTime ended =
-                NetworkUtil::getQDateTimeFrom8ByteMsSinceEpoch(message, offset + 12);
-            int permillage = NetworkUtil::get2BytesSigned(message, offset + 20);
-            quint16 status = NetworkUtil::get2Bytes(message, offset + 22);
-            offset += 24;
+                NetworkUtil::getQDateTimeFrom8ByteMsSinceEpoch(message, offset + 8);
+            int permillage = NetworkUtil::get2BytesSigned(message, offset + 16);
+            quint16 status = NetworkUtil::get2Bytes(message, offset + 18);
+            offset += 20;
 
             bool ok;
             auto hash = NetworkProtocol::getHash(message, offset, &ok);
@@ -3831,6 +3844,9 @@ namespace PMP::Client
 
             auto hashId = _hashIdRepository->getOrRegisterId(hash);
             bool validForScoring = status & 1;
+
+            qDebug() << "history entry: user" << userId << " track ID" << trackId
+                     << " hash" << hash << " started" << started;
 
             entries.append(
                 HistoryEntry { hashId, userId, started, ended, permillage,

--- a/src/client/serverconnection.h
+++ b/src/client/serverconnection.h
@@ -41,6 +41,7 @@
 #include "collectiontrackinfo.h"
 #include "historyentry.h"
 #include "localhashid.h"
+#include "trackhashorid.h"
 
 #include <QByteArray>
 #include <QDateTime>
@@ -61,6 +62,7 @@ namespace PMP::Client
     class LocalHashIdRepository;
     class ServerCapabilities;
     class ServerCapabilitiesImpl;
+    class TrackServerIdRepository;
 
     class InactivityTimer : public QObject
     {
@@ -127,6 +129,7 @@ namespace PMP::Client
     public:
         explicit ServerConnection(QObject* parent,
                                   LocalHashIdRepository* hashIdRepository,
+                                  TrackServerIdRepository* trackServerIdRepository,
                                   ServerEventSubscription eventSubscription =
                                                       ServerEventSubscription::AllEvents);
         ~ServerConnection();
@@ -157,6 +160,7 @@ namespace PMP::Client
                                                                 qint64 delayMilliseconds);
         SimpleFuture<AnyResultMessageCode> deactivateDelayedStart();
         RequestID insertQueueEntryAtIndex(LocalHashId hashId, quint32 index);
+        RequestID insertQueueEntryAtIndex(TrackHashOrId track, quint32 index);
         RequestID insertSpecialQueueItemAtIndex(SpecialQueueItemType itemType, int index,
                                        QueueIndexType indexType = QueueIndexType::Normal);
         RequestID duplicateQueueEntry(uint queueID);
@@ -207,7 +211,9 @@ namespace PMP::Client
         void moveQueueEntry(uint queueID, qint16 offsetDiff);
 
         void insertQueueEntryAtFront(LocalHashId hashId);
+        void insertQueueEntryAtFront(TrackHashOrId track);
         void insertQueueEntryAtEnd(LocalHashId hashId);
+        void insertQueueEntryAtEnd(TrackHashOrId track);
 
         void sendQueueEntryInfoRequest(uint queueID);
         void sendQueueEntryInfoRequest(QList<uint> const& queueIDs);
@@ -439,11 +445,14 @@ namespace PMP::Client
 
         void receivedServerClockTime(QDateTime serverClockTime);
 
+        void replaceTrackHashWithServerIdIfPossible(TrackHashOrId& track);
+
         static const quint16 ClientProtocolNo;
         static const int KeepAliveIntervalMs;
         static const int KeepAliveReplyTimeoutMs;
 
         LocalHashIdRepository* _hashIdRepository;
+        TrackServerIdRepository* _trackServerIdRepository;
         ServerCapabilitiesImpl* _serverCapabilities;
         DisconnectReason _disconnectReason;
         InactivityTimer* _inactivityTimer;

--- a/src/client/serverdiscoverer.cpp
+++ b/src/client/serverdiscoverer.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -22,6 +22,7 @@
 #include "common/networkutil.h"
 
 #include "client/localhashidrepository.h"
+#include "client/trackserveridrepository.h"
 
 #include "serverconnection.h"
 
@@ -38,6 +39,7 @@ namespace PMP::Client
     ServerDiscoverer::ServerDiscoverer(QObject* parent)
      : QObject(parent),
        _localHashIdRepository(new LocalHashIdRepository()),
+       _trackServerIdRepository(new TrackServerIdRepository()),
        _socket(new QUdpSocket(this)),
        _scanInProgress(false)
     {
@@ -58,6 +60,7 @@ namespace PMP::Client
     ServerDiscoverer::~ServerDiscoverer()
     {
         delete _localHashIdRepository;
+        delete _trackServerIdRepository;
     }
 
     bool ServerDiscoverer::canDoScan() const
@@ -163,7 +166,7 @@ namespace PMP::Client
 
         _addressesBeingProbed << serverAndPort;
         auto probe = new ServerProbe(this, serverAndPort.first, serverAndPort.second,
-                                     _localHashIdRepository);
+                                     _localHashIdRepository, _trackServerIdRepository);
         connect(probe, &ServerProbe::foundServer, this, &ServerDiscoverer::onFoundServer);
         connect(
             probe, &ServerProbe::destroyed,
@@ -220,12 +223,15 @@ namespace PMP::Client
     // ============================================================================== //
 
     ServerProbe::ServerProbe(QObject* parent, QHostAddress const& address, quint16 port,
-                             LocalHashIdRepository* localHashIdRepository)
+                             LocalHashIdRepository* localHashIdRepository,
+                             TrackServerIdRepository *trackServerIdRepository)
      : QObject(parent),
        _address(address),
        _port(port),
-       _connection(new ServerConnection(this, localHashIdRepository,
-                                          ServerEventSubscription::ServerHealthMessages)),
+       _connection(new ServerConnection(this,
+                                        localHashIdRepository,
+                                        trackServerIdRepository,
+                                        ServerEventSubscription::ServerHealthMessages)),
        _serverNameType(0)
     {
         qDebug() << "ServerProbe created for" << address << "and port" << port;

--- a/src/client/serverdiscoverer.h
+++ b/src/client/serverdiscoverer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -35,6 +35,7 @@ namespace PMP::Client
     class LocalHashIdRepository;
     class ServerConnection;
     class ServerProbe;
+    class TrackServerIdRepository;
 
     class ServerDiscoverer : public QObject
     {
@@ -73,6 +74,7 @@ namespace PMP::Client
         };
 
         LocalHashIdRepository* _localHashIdRepository;
+        TrackServerIdRepository* _trackServerIdRepository;
         QList<QHostAddress> _localHostNetworkAddresses;
         QUdpSocket* _socket;
         QSet<QPair<QHostAddress, quint16>> _addressesBeingProbed;
@@ -85,7 +87,8 @@ namespace PMP::Client
         Q_OBJECT
     public:
         ServerProbe(QObject* parent, QHostAddress const& address, quint16 port,
-                    LocalHashIdRepository* localHashIdRepository);
+                    LocalHashIdRepository* localHashIdRepository,
+                    TrackServerIdRepository* trackServerIdRepository);
 
     Q_SIGNALS:
         void foundServer(QHostAddress address, quint16 port,

--- a/src/client/trackhashorid.h
+++ b/src/client/trackhashorid.h
@@ -1,0 +1,131 @@
+/*
+    Copyright (C) 2025, Kevin André <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_CLIENT_TRACKHASHORID_H
+#define PMP_CLIENT_TRACKHASHORID_H
+
+#include "common/filehash.h"
+#include "common/nullable.h"
+
+#include <QDebug>
+
+#include <variant>
+
+namespace PMP::Client
+{
+    class TrackHashOrId
+    {
+    public:
+        TrackHashOrId()
+         : _data{}
+        {
+            //
+        }
+
+        TrackHashOrId(FileHash hash)
+         : _data(hash.isNull() ? datatype() : datatype(hash))
+        {
+            //
+        }
+
+        TrackHashOrId(quint64 id)
+         : _data(id == 0 ? datatype() : datatype(id))
+        {
+            //
+        }
+
+        constexpr bool isNull() const
+        {
+            return std::holds_alternative<std::monostate>(_data);
+        }
+
+        constexpr bool isHash() const
+        {
+            return std::holds_alternative<FileHash>(_data);
+        }
+
+        constexpr bool isId() const
+        {
+            return std::holds_alternative<quint64>(_data);
+        }
+
+        Nullable<FileHash> toHash() const
+        {
+            if (std::holds_alternative<FileHash>(_data))
+                return std::get<FileHash>(_data);
+
+            return null;
+        }
+
+        Nullable<quint64> toId() const
+        {
+            if (std::holds_alternative<quint64>(_data))
+                return std::get<quint64>(_data);
+
+            return null;
+        }
+
+        bool operator==(TrackHashOrId const& other) const
+        {
+            if (std::holds_alternative<std::monostate>(_data))
+                return std::holds_alternative<std::monostate>(other._data);
+
+            if (std::holds_alternative<FileHash>(_data))
+            {
+                return std::holds_alternative<FileHash>(other._data)
+                       && std::get<FileHash>(_data) == std::get<FileHash>(other._data);
+            }
+
+            //if (std::holds_alternative<quint64>(_data))
+            {
+                return std::holds_alternative<quint64>(other._data)
+                       && std::get<quint64>(_data) == std::get<quint64>(other._data);
+            }
+        }
+
+        bool operator==(FileHash const& other) const
+        {
+            return std::holds_alternative<FileHash>(_data)
+                   && std::get<FileHash>(_data) == other;
+        }
+
+        bool operator==(quint64 const& otherId) const
+        {
+            return std::holds_alternative<quint64>(_data)
+                   && std::get<quint64>(_data) == otherId;
+        }
+
+    private:
+        typedef std::variant<std::monostate, FileHash, quint64> datatype;
+        datatype _data;
+    };
+
+    inline QDebug operator<<(QDebug debug, TrackHashOrId const& track)
+    {
+        if (track.isNull())
+            debug << "(null)";
+        else if (track.isHash())
+            debug << track.toHash().value();
+        else //if (track.isId())
+            debug << "{ID" << track.toId().value() << "}";
+
+        return debug;
+    }
+}
+#endif

--- a/src/client/trackserveridrepository.cpp
+++ b/src/client/trackserveridrepository.cpp
@@ -1,0 +1,94 @@
+/*
+    Copyright (C) 2025, Kevin André <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "trackserveridrepository.h"
+
+namespace PMP::Client
+{
+    TrackServerIdRepository::TrackServerIdRepository()
+    {
+        //
+    }
+
+    void TrackServerIdRepository::registerHashWithId(const FileHash& hash,
+                                                     quint64 trackServerId)
+    {
+        Q_ASSERT_X(hash.isNull() == false,
+                   "TrackServerIdRepository::registerHashWithId",
+                   "hash is null");
+
+        Q_ASSERT_X(trackServerId > 0,
+                   "TrackServerIdRepository::registerHashWithId",
+                   "track server ID is zero");
+
+        QWriteLocker lock(&_lock);
+
+        auto itByHash = _hashToServerId.constFind(hash);
+        auto itById = _serverIdToHash.constFind(trackServerId);
+
+        bool hashFound = itByHash != _hashToServerId.constEnd();
+        bool idFound = itById != _serverIdToHash.constEnd();
+
+        Q_ASSERT_X(hashFound == idFound,
+                   "TrackServerIdRepository::registerHashWithId",
+                   "hash or ID not both present or absent in repository");
+
+        if (hashFound)
+        {
+            Q_ASSERT_X(itByHash.value() == trackServerId,
+                       "TrackServerIdRepository::registerHashWithId",
+                       "hash in repository linked to different ID");
+
+            Q_ASSERT_X(itById.value() == hash,
+                       "TrackServerIdRepository::registerHashWithId",
+                       "ID in repository linked to different hash");
+
+            return; /* nothing to register */
+        }
+
+        _hashToServerId.insert(hash, trackServerId);
+        _serverIdToHash.insert(trackServerId, hash);
+    }
+
+    Nullable<quint64> TrackServerIdRepository::getServerIdForHash(
+        const FileHash& hash) const
+    {
+        QReadLocker lock(&_lock);
+
+        auto it = _hashToServerId.constFind(hash);
+
+        if (it == _hashToServerId.constEnd())
+            return null;
+
+        return it.value();
+    }
+
+    Nullable<FileHash> TrackServerIdRepository::getHashForServerId(
+        quint64 trackServerId) const
+    {
+        QReadLocker lock(&_lock);
+
+        auto it = _serverIdToHash.constFind(trackServerId);
+
+        if (it == _serverIdToHash.constEnd())
+            return null;
+
+        return it.value();
+    }
+}

--- a/src/client/trackserveridrepository.h
+++ b/src/client/trackserveridrepository.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2025, Kevin André <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_CLIENT_TRACKSERVERIDREPOSITORY_H
+#define PMP_CLIENT_TRACKSERVERIDREPOSITORY_H
+
+#include "common/filehash.h"
+#include "common/nullable.h"
+
+#include <QHash>
+#include <QReadWriteLock>
+
+namespace PMP::Client
+{
+    class TrackServerIdRepository
+    {
+    public:
+        TrackServerIdRepository();
+
+        void registerHashWithId(FileHash const& hash, quint64 trackServerId);
+
+        Nullable<quint64> getServerIdForHash(FileHash const& hash) const;
+        Nullable<FileHash> getHashForServerId(quint64 trackServerId) const;
+
+    private:
+        mutable QReadWriteLock _lock;
+        QHash<FileHash, quint64> _hashToServerId;
+        QHash<quint64, FileHash> _serverIdToHash;
+    };
+}
+#endif

--- a/src/cmd-remote/commandbase.cpp
+++ b/src/cmd-remote/commandbase.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -180,6 +180,10 @@ namespace PMP
 
         case ResultMessageErrorCode::InvalidUserId:
             errorOutput = "invalid user ID";
+            break;
+
+        case ResultMessageErrorCode::InvalidTrackId:
+            errorOutput = "invalid track ID";
             break;
 
         case PMP::ResultMessageErrorCode::MaximumQueueSizeExceeded:

--- a/src/cmd-remote/commandlineclient.cpp
+++ b/src/cmd-remote/commandlineclient.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -22,6 +22,7 @@
 #include "client/localhashidrepository.h"
 #include "client/serverconnection.h"
 #include "client/serverinterface.h"
+#include "client/trackserveridrepository.h"
 
 #include "command.h"
 
@@ -43,6 +44,7 @@ namespace PMP
        _username(username),
        _password(password),
        _hashIdRepository(new LocalHashIdRepository()),
+       _trackServerIdRepository(new TrackServerIdRepository()),
        _serverConnection(nullptr),
        _serverInterface(nullptr),
        _command(command),
@@ -52,6 +54,7 @@ namespace PMP
         _serverConnection =
                 new ServerConnection(this,
                                      _hashIdRepository,
+                                     _trackServerIdRepository,
                                      ServerEventSubscription::AllEvents);
         _serverInterface = new ServerInterfaceImpl(_serverConnection);
 
@@ -137,6 +140,7 @@ namespace PMP
     CommandlineClient::~CommandlineClient()
     {
         delete _hashIdRepository;
+        delete _trackServerIdRepository;
     }
 
     void CommandlineClient::start()

--- a/src/cmd-remote/commandlineclient.h
+++ b/src/cmd-remote/commandlineclient.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -33,6 +33,7 @@ namespace PMP::Client
     class LocalHashIdRepository;
     class ServerConnection;
     class ServerInterface;
+    class TrackServerIdRepository;
 }
 
 namespace PMP
@@ -69,6 +70,7 @@ namespace PMP
         QString _username;
         QString _password;
         Client::LocalHashIdRepository* _hashIdRepository;
+        Client::TrackServerIdRepository* _trackServerIdRepository;
         QPointer<Client::ServerConnection> _serverConnection;
         QPointer<Client::ServerInterface> _serverInterface;
         QPointer<Command> _command;

--- a/src/cmd-remote/queuecommands.cpp
+++ b/src/cmd-remote/queuecommands.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,7 +21,6 @@
 
 #include "common/util.h"
 
-#include "client/localhashidrepository.h"
 #include "client/queuecontroller.h"
 #include "client/queueentryinfostorage.h"
 #include "client/queuemonitor.h"
@@ -270,9 +269,9 @@ namespace PMP
 
     /* ===== QueueInsertTrackCommand ===== */
 
-    QueueInsertTrackCommand::QueueInsertTrackCommand(const FileHash& hash, int index,
-                                                     QueueIndexType indexType)
-     : _hash(hash),
+    QueueInsertTrackCommand::QueueInsertTrackCommand(const TrackHashOrId& track,
+                                                     int index, QueueIndexType indexType)
+     : _track(track),
        _index(index),
        _indexType(indexType)
     {
@@ -317,16 +316,12 @@ namespace PMP
 
     void QueueInsertTrackCommand::insertNormal(Client::ServerInterface* serverInterface)
     {
-        auto hashId = serverInterface->hashIdRepository()->getOrRegisterId(_hash);
-
         _requestId =
-            serverInterface->queueController().insertQueueEntryAtIndex(hashId, _index);
+            serverInterface->queueController().insertQueueEntryAtIndex(_track, _index);
     }
 
     void QueueInsertTrackCommand::insertReversed(Client::ServerInterface* serverInterface)
     {
-        auto hashId = serverInterface->hashIdRepository()->getOrRegisterId(_hash);
-
         auto* queueController = &serverInterface->queueController();
 
         auto* queueMonitor = &serverInterface->queueMonitor();
@@ -336,7 +331,7 @@ namespace PMP
                 this, &QueueInsertTrackCommand::listenerSlot);
 
         addStep(
-            [this, hashId, queueMonitor, queueController]() -> StepResult
+            [this, queueMonitor, queueController]() -> StepResult
             {
                 if (!queueMonitor->isQueueLengthKnown())
                     return StepResult::stepIncomplete();
@@ -349,7 +344,7 @@ namespace PMP
                 }
 
                 _requestId =
-                    queueController->insertQueueEntryAtIndex(hashId, insertionIndex);
+                    queueController->insertQueueEntryAtIndex(_track, insertionIndex);
 
                 return StepResult::stepCompleted();
             }

--- a/src/cmd-remote/queuecommands.h
+++ b/src/cmd-remote/queuecommands.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -24,6 +24,8 @@
 #include "common/queueindextype.h"
 #include "common/requestid.h"
 #include "common/specialqueueitemtype.h"
+
+#include "client/trackhashorid.h"
 
 #include "commandbase.h"
 
@@ -78,7 +80,7 @@ namespace PMP
     {
         Q_OBJECT
     public:
-        QueueInsertTrackCommand(FileHash const& hash, int index,
+        QueueInsertTrackCommand(Client::TrackHashOrId const& track, int index,
                                 QueueIndexType indexType);
 
     protected:
@@ -88,7 +90,7 @@ namespace PMP
         void insertNormal(Client::ServerInterface* serverInterface);
         void insertReversed(Client::ServerInterface* serverInterface);
 
-        FileHash _hash;
+        Client::TrackHashOrId _track;
         int _index;
         QueueIndexType _indexType;
         RequestID _requestId;

--- a/src/common/networkprotocol.cpp
+++ b/src/common/networkprotocol.cpp
@@ -274,11 +274,16 @@ namespace PMP
     const QByteArray NetworkProtocol::_fileHashAllZeroes =
             Util::generateZeroedMemory(FILEHASH_BYTECOUNT);
 
+    void NetworkProtocol::appendNullHash(QByteArray& buffer)
+    {
+        buffer += _fileHashAllZeroes;
+    }
+
     void NetworkProtocol::appendHash(QByteArray& buffer, Nullable<FileHash> hash)
     {
         if (hash.isNull())
         {
-            buffer += _fileHashAllZeroes;
+            appendNullHash(buffer);
             return;
         }
 
@@ -289,7 +294,7 @@ namespace PMP
     {
         if (hash.isNull())
         {
-            buffer += _fileHashAllZeroes;
+            appendNullHash(buffer);
             return;
         }
 

--- a/src/common/networkprotocol.cpp
+++ b/src/common/networkprotocol.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -282,8 +282,12 @@ namespace PMP
             return;
         }
 
-        auto hashValue = hash.value();
-        if (hashValue.isNull())
+        appendHash(buffer, hash.value());
+    }
+
+    void NetworkProtocol::appendHash(QByteArray& buffer, const FileHash& hash)
+    {
+        if (hash.isNull())
         {
             buffer += _fileHashAllZeroes;
             return;
@@ -291,9 +295,9 @@ namespace PMP
 
         auto oldBufferLength = buffer.length();
 
-        NetworkUtil::append8Bytes(buffer, hashValue.length());
-        buffer += hashValue.SHA1();
-        buffer += hashValue.MD5();
+        NetworkUtil::append8Bytes(buffer, hash.length());
+        buffer += hash.SHA1();
+        buffer += hash.MD5();
 
         auto newBufferLength = buffer.length();
         Q_ASSERT_X(newBufferLength - oldBufferLength == FILEHASH_BYTECOUNT,

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -64,7 +64,7 @@ Changes for each version:
   25: client msg 27, server msg 36, error codes 26 & 120 & 121: fetch personal track history
   26: parameterless actions 60 & 61, server msg 37: full indexation and quick scan for new files
   27: client msg 28, server msg 38: requesting individual track info
-  28: changed server msg 21 & 38 ... : send track IDs to client
+  28: changed server msg 18 & 19 & 21 & 36 & 38 ... : include track IDs
 */
 
 namespace PMP

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -233,6 +233,7 @@ namespace PMP
 
         static const int FILEHASH_BYTECOUNT = 8 /*length*/ + 20 /*SHA-1*/ + 16 /*MD5*/;
         static void appendHash(QByteArray& buffer, Nullable<FileHash> hash);
+        static void appendHash(QByteArray& buffer, const FileHash& hash);
         static FileHash getHash(const QByteArray& buffer, int position, bool* ok);
 
         static qint16 getHashUserDataFieldsMaskForProtocolVersion(int version);

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -64,6 +64,7 @@ Changes for each version:
   25: client msg 27, server msg 36, error codes 26 & 120 & 121: fetch personal track history
   26: parameterless actions 60 & 61, server msg 37: full indexation and quick scan for new files
   27: client msg 28, server msg 38: requesting individual track info
+  28: changed server msg 38 ... : send track IDs to client
 */
 
 namespace PMP

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -64,7 +64,7 @@ Changes for each version:
   25: client msg 27, server msg 36, error codes 26 & 120 & 121: fetch personal track history
   26: parameterless actions 60 & 61, server msg 37: full indexation and quick scan for new files
   27: client msg 28, server msg 38: requesting individual track info
-  28: changed server msg 38 ... : send track IDs to client
+  28: changed server msg 21 & 38 ... : send track IDs to client
 */
 
 namespace PMP
@@ -233,6 +233,7 @@ namespace PMP
         static QueueEntryType trackStatusToQueueEntryType(quint16 status);
 
         static const int FILEHASH_BYTECOUNT = 8 /*length*/ + 20 /*SHA-1*/ + 16 /*MD5*/;
+        static void appendNullHash(QByteArray& buffer);
         static void appendHash(QByteArray& buffer, Nullable<FileHash> hash);
         static void appendHash(QByteArray& buffer, const FileHash& hash);
         static FileHash getHash(const QByteArray& buffer, int position, bool* ok);

--- a/src/common/networkprotocol.h
+++ b/src/common/networkprotocol.h
@@ -64,7 +64,7 @@ Changes for each version:
   25: client msg 27, server msg 36, error codes 26 & 120 & 121: fetch personal track history
   26: parameterless actions 60 & 61, server msg 37: full indexation and quick scan for new files
   27: client msg 28, server msg 38: requesting individual track info
-  28: changed server msg 18 & 19 & 21 & 36 & 38 ... : include track IDs
+  28: client msgs 15 & 16 & 19, server msgs 18 & 19 & 21 & 36 & 38, error code 27 : server track IDs
 */
 
 namespace PMP

--- a/src/common/resultmessageerrorcode.h
+++ b/src/common/resultmessageerrorcode.h
@@ -62,6 +62,7 @@ namespace PMP
         InvalidQueueItemType = 24, /**< The specified queue item type was not valid */
         InvalidTimeSpan = 25, /**< The specified time span was not valid */
         InvalidUserId = 26, /**< The specified user ID was not valid */
+        InvalidTrackId = 27, /**< The specified track ID was not valid */
 
         /* ---------- errors regarding state ---------- */
 

--- a/src/common/resultorerror.h
+++ b/src/common/resultorerror.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -67,13 +67,13 @@ namespace PMP
         constexpr bool succeeded() const { return _result.hasValue(); }
         constexpr bool failed() const { return _result.isNull(); }
 
-        ResultType result() const
+        ResultType result() const // TODO: return reference instead
         {
             Q_ASSERT_X(succeeded(), "ResultOrError::result()", "no result available");
             return _result.value();
         }
 
-        ErrorType error() const
+        ErrorType error() const // TODO: return reference instead
         {
             Q_ASSERT_X(failed(), "ResultOrError::error()", "no error available");
             return _error.value();

--- a/src/desktop-remote/mainwindow.cpp
+++ b/src/desktop-remote/mainwindow.cpp
@@ -31,6 +31,7 @@
 #include "client/scrobblingcontroller.h"
 #include "client/serverconnection.h"
 #include "client/serverinterface.h"
+#include "client/trackserveridrepository.h"
 
 #include "collectionwidget.h"
 #include "connectionwidget.h"
@@ -70,6 +71,7 @@ namespace PMP
        _leftStatusTimer(new QTimer(this)),
        _connectionWidget(new ConnectionWidget(this)),
        _hashIdRepository(new LocalHashIdRepository()),
+       _trackServerIdRepository(new TrackServerIdRepository()),
        _musicCollectionDock(new QDockWidget(tr("Music collection"), this)),
        _powerManagement(new PowerManagement(this))
     {
@@ -123,6 +125,7 @@ namespace PMP
     MainWindow::~MainWindow()
     {
         delete _hashIdRepository;
+        delete _trackServerIdRepository;
     }
 
     void MainWindow::createActions()
@@ -654,7 +657,9 @@ namespace PMP
 
     void MainWindow::onDoConnect(QString server, uint port)
     {
-        _connection = new ServerConnection(this, _hashIdRepository);
+        _connection = new ServerConnection(this,
+                                           _hashIdRepository,
+                                           _trackServerIdRepository);
         _serverInterface = new ServerInterfaceImpl(_connection);
 
         auto* generalController = &_serverInterface->generalController();

--- a/src/desktop-remote/mainwindow.h
+++ b/src/desktop-remote/mainwindow.h
@@ -38,6 +38,7 @@ namespace PMP::Client
     class QueueHashesMonitor;
     class ServerConnection;
     class ServerInterface;
+    class TrackServerIdRepository;
 }
 
 namespace PMP
@@ -120,6 +121,7 @@ namespace PMP
 
         ConnectionWidget* _connectionWidget;
         Client::LocalHashIdRepository* _hashIdRepository;
+        Client::TrackServerIdRepository* _trackServerIdRepository;
         Client::ServerConnection* _connection { nullptr };
         Client::ServerInterface* _serverInterface { nullptr };
         Client::QueueHashesMonitor* _queueHashesMonitor { nullptr };

--- a/src/server/collectionmonitor.cpp
+++ b/src/server/collectionmonitor.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -55,7 +55,7 @@ namespace PMP::Server
         checkNeedToSendNotifications();
     }
 
-    void CollectionMonitor::hashTagInfoChanged(FileHash hash,
+    void CollectionMonitor::hashTagInfoChanged(uint hashId, FileHash hash,
                                                QString title, QString artist,
                                                QString album, QString albumArtist,
                                                qint32 lengthInMilliseconds)
@@ -71,6 +71,7 @@ namespace PMP::Server
 
         if (infoStillTheSame) return;
 
+        info.hashId = hashId;
         info.title = title;
         info.artist = artist;
         info.album = album;
@@ -162,13 +163,14 @@ namespace PMP::Server
         QVector<CollectionTrackInfo> notifications;
         notifications.reserve(hashes.size());
 
-        for (FileHash const& h : hashes)
+        for (FileHash const& hash : hashes)
         {
-            auto it = _collection.find(h);
+            auto it = _collection.find(hash);
             if (it == _collection.end()) continue; /* disappeared?? */
 
             const HashInfo& value = it.value();
-            CollectionTrackInfo info(h, value.isAvailable, value.title, value.artist,
+            CollectionTrackInfo info(value.hashId, hash, value.isAvailable,
+                                     value.title, value.artist,
                                      value.album, value.albumArtist,
                                      value.lengthInMilliseconds);
             notifications.append(info);
@@ -179,17 +181,27 @@ namespace PMP::Server
 
     void CollectionMonitor::emitAvailabilityNotifications(QVector<FileHash> hashes)
     {
-        QVector<FileHash> available, unavailable;
+        QVector<FileHashWithId> available, unavailable;
 
-        for (FileHash const& h : hashes)
+        for (FileHash const& hash : hashes)
         {
-            auto it = _collection.find(h);
+            auto it = _collection.find(hash);
             if (it == _collection.end()) continue; /* disappeared?? */
 
-            if (it.value().isAvailable)
-                available.append(h);
+            auto const& hashInfo = it.value();
+
+            auto id = hashInfo.hashId;
+            if (id == 0)
+            {
+                qWarning() << "CollectionMonitor: cannot emit availability notification"
+                           << "for hash" << hash << "because its ID is not known";
+                continue;
+            }
+
+            if (hashInfo.isAvailable)
+                available.append({ hash, id });
             else
-                unavailable.append(h);
+                unavailable.append({ hash, id });
         }
 
         Q_EMIT hashAvailabilityChanged(available, unavailable);

--- a/src/server/collectionmonitor.h
+++ b/src/server/collectionmonitor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,6 +21,7 @@
 #define PMP_SERVER_COLLECTIONMONITOR_H
 
 #include "collectiontrackinfo.h"
+#include "filehashwithid.h"
 
 #include <QHash>
 #include <QMetaType>
@@ -40,13 +41,14 @@ namespace PMP::Server
     public Q_SLOTS:
         void hashBecameAvailable(PMP::FileHash hash);
         void hashBecameUnavailable(PMP::FileHash hash);
-        void hashTagInfoChanged(PMP::FileHash hash, QString title, QString artist,
+        void hashTagInfoChanged(uint hashId, PMP::FileHash hash,
+                                QString title, QString artist,
                                 QString album, QString albumArtist,
                                 qint32 lengthInMilliseconds);
 
     Q_SIGNALS:
-        void hashAvailabilityChanged(QVector<PMP::FileHash> available,
-                                     QVector<PMP::FileHash> unavailable);
+        void hashAvailabilityChanged(QVector<PMP::Server::FileHashWithId> available,
+                                     QVector<PMP::Server::FileHashWithId> unavailable);
         void hashInfoChanged(QVector<PMP::Server::CollectionTrackInfo> changes);
 
     private Q_SLOTS:
@@ -59,15 +61,10 @@ namespace PMP::Server
 
         struct HashInfo
         {
-            bool isAvailable;
+            uint hashId { 0 };
+            bool isAvailable { false };
             QString title, artist, album, albumArtist;
-            qint32 lengthInMilliseconds;
-
-            HashInfo()
-             : isAvailable(false), lengthInMilliseconds(-1)
-            {
-                //
-            }
+            qint32 lengthInMilliseconds { -1 };
         };
 
         struct Changed

--- a/src/server/collectiontrackinfo.h
+++ b/src/server/collectiontrackinfo.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2015-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2015-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -31,27 +31,30 @@ namespace PMP::Server
     {
     public:
         CollectionTrackInfo()
-         : _isAvailable(false), _lengthInMs(-1)
+         : _hashId(0), _isAvailable(false), _lengthInMs(-1)
         {
             //
         }
 
-        CollectionTrackInfo(FileHash const& hash, bool isAvailable)
-         : _hash(hash), _isAvailable(isAvailable), _lengthInMs(-1)
+        CollectionTrackInfo(uint hashId, FileHash const& hash, bool isAvailable)
+         : _hashId(hashId), _hash(hash), _isAvailable(isAvailable),
+            _lengthInMs(-1)
         {
             //
         }
 
-        CollectionTrackInfo(FileHash const& hash, bool isAvailable,
+        CollectionTrackInfo(uint hashId, FileHash const& hash, bool isAvailable,
                             QString const& title, QString const& artist,
                             QString const& album, QString const& albumArtist,
                             qint32 lengthInMilliseconds)
-         : _hash(hash), _isAvailable(isAvailable), _lengthInMs(lengthInMilliseconds),
+         : _hashId(hashId), _hash(hash), _isAvailable(isAvailable),
+            _lengthInMs(lengthInMilliseconds),
             _title(title), _artist(artist), _album(album), _albumArtist(albumArtist)
         {
             //
         }
 
+        uint hashId() const { return _hashId; }
         const FileHash& hash() const { return _hash; }
 
         void setAvailable(bool available) { _isAvailable = available; }
@@ -75,6 +78,7 @@ namespace PMP::Server
         }
 
     private:
+        uint _hashId;
         FileHash _hash;
         bool _isAvailable;
         qint32 _lengthInMs;

--- a/src/server/collectiontrackinfo.h
+++ b/src/server/collectiontrackinfo.h
@@ -31,30 +31,30 @@ namespace PMP::Server
     {
     public:
         CollectionTrackInfo()
-         : _hashId(0), _isAvailable(false), _lengthInMs(-1)
+         : _trackId(0), _isAvailable(false), _lengthInMs(-1)
         {
             //
         }
 
-        CollectionTrackInfo(uint hashId, FileHash const& hash, bool isAvailable)
-         : _hashId(hashId), _hash(hash), _isAvailable(isAvailable),
+        CollectionTrackInfo(uint trackId, FileHash const& hash, bool isAvailable)
+         : _trackId(trackId), _hash(hash), _isAvailable(isAvailable),
             _lengthInMs(-1)
         {
             //
         }
 
-        CollectionTrackInfo(uint hashId, FileHash const& hash, bool isAvailable,
+        CollectionTrackInfo(uint trackId, FileHash const& hash, bool isAvailable,
                             QString const& title, QString const& artist,
                             QString const& album, QString const& albumArtist,
                             qint32 lengthInMilliseconds)
-         : _hashId(hashId), _hash(hash), _isAvailable(isAvailable),
+         : _trackId(trackId), _hash(hash), _isAvailable(isAvailable),
             _lengthInMs(lengthInMilliseconds),
             _title(title), _artist(artist), _album(album), _albumArtist(albumArtist)
         {
             //
         }
 
-        uint hashId() const { return _hashId; }
+        uint trackId() const { return _trackId; }
         const FileHash& hash() const { return _hash; }
 
         void setAvailable(bool available) { _isAvailable = available; }
@@ -78,7 +78,7 @@ namespace PMP::Server
         }
 
     private:
-        uint _hashId;
+        uint _trackId;
         FileHash _hash;
         bool _isAvailable;
         qint32 _lengthInMs;

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -2756,7 +2756,7 @@ namespace PMP::Server
         _serverInterface->getPossibleFilenamesForQueueEntry(queueId)
             .handleOnEventLoop(
                 this,
-                [this, queueId](ResultOrError<QVector<QString>, Result> outcome)
+                [this, queueId](ResultOrError<QVector<QString>, Error> outcome)
                 {
                     if (outcome.succeeded())
                         sendPossibleTrackFilenames(queueId, outcome.result());
@@ -2983,7 +2983,7 @@ namespace PMP::Server
         auto future = _serverInterface->getHashInfo(hash);
         future.handleOnEventLoop(
             this,
-            [this, clientReference](ResultOrError<CollectionTrackInfo, Result> outcome)
+            [this, clientReference](ResultOrError<CollectionTrackInfo, Error> outcome)
             {
                 if (outcome.succeeded())
                     sendHashInfoReply(clientReference, outcome.result());
@@ -3016,7 +3016,7 @@ namespace PMP::Server
 
         future.handleOnEventLoop(
             this,
-            [this, clientReference](ResultOrError<HistoryFragment, Result> outcome)
+            [this, clientReference](ResultOrError<HistoryFragment, Error> outcome)
             {
                 if (outcome.succeeded())
                     sendHistoryFragmentMessage(clientReference, outcome.result());

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -944,11 +944,15 @@ namespace PMP::Server
             return;
         }
 
+        bool includeTrackId = _clientProtocolNo >= 28;
+
         quint32 nextStartId = lowestEntryId > 0 ? lowestEntryId : 0;
 
         QByteArray message;
         message.reserve(2 + 2 + 4 + 4 + fragment.entries().size() *
-                            (4 + 8 + 8 + 2 + 2 + NetworkProtocol::FILEHASH_BYTECOUNT));
+                            (4
+                                + (includeTrackId ? 8 : 0)
+                                + 8 + 8 + 2 + 2 + NetworkProtocol::FILEHASH_BYTECOUNT));
         NetworkProtocol::append2Bytes(message, ServerMessageType::HistoryFragmentMessage);
         NetworkUtil::append2BytesUnsigned(message, fragment.entries().size());
         NetworkUtil::append4Bytes(message, clientReference);
@@ -961,6 +965,12 @@ namespace PMP::Server
             qint16 permillage = static_cast<qint16>(entry.permillage());
 
             NetworkUtil::append4Bytes(message, entry.userId());
+
+            if (includeTrackId)
+            {
+                NetworkUtil::append8Bytes(message, entry.trackId());
+            }
+
             NetworkUtil::append8ByteQDateTimeMsSinceEpoch(message, entry.started());
             NetworkUtil::append8ByteQDateTimeMsSinceEpoch(message, entry.ended());
             NetworkUtil::append2BytesSigned(message, permillage);

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -1061,7 +1061,7 @@ namespace PMP::Server
 
         if (includeTrackId)
         {
-            NetworkUtil::append8Bytes(message, info.hashId());
+            NetworkUtil::append8Bytes(message, info.trackId());
         }
 
         NetworkUtil::append2BytesUnsigned(message, titleData.size());
@@ -1128,6 +1128,33 @@ namespace PMP::Server
         sendBinaryMessage(message);
     }
 
+    quint16 ConnectedClient::createTrackStatusFor(QueueEntryIdsAndHash const& entry)
+    {
+        bool isTrack = false;
+
+        switch (entry.kind)
+        {
+        case QueueEntryKind::Track:
+            isTrack = true;
+            break; /* handled below */
+
+        case QueueEntryKind::Break:
+            return NetworkProtocol::createTrackStatusFor(SpecialQueueItemType::Break);
+
+        case QueueEntryKind::Barrier:
+            return NetworkProtocol::createTrackStatusFor(SpecialQueueItemType::Barrier);
+        }
+
+        if (!isTrack)
+        {
+            qWarning() << "Unhandled QueueEntryKind" << int(entry.kind)
+                       << "at queue entry with ID" << entry.queueId;
+            return NetworkProtocol::createTrackStatusForUnknownThing();
+        }
+
+        return NetworkProtocol::createTrackStatusForTrack();
+    }
+
     quint16 ConnectedClient::createTrackStatusFor(QSharedPointer<QueueEntry> entry)
     {
         switch (entry->kind())
@@ -1144,7 +1171,8 @@ namespace PMP::Server
 
         if (!entry->isTrack()) /* unhandled non-track thing */
         {
-            qWarning() << "Unhandled QueueEntryKind" << int(entry->kind());
+            qWarning() << "Unhandled QueueEntryKind" << int(entry->kind())
+                       << "at queue entry with ID" << entry->queueID();
             return NetworkProtocol::createTrackStatusForUnknownThing();
         }
 
@@ -1279,46 +1307,81 @@ namespace PMP::Server
         sendBinaryMessage(message);
     }
 
-    void ConnectedClient::sendQueueEntryHashMessage(const QList<quint32>& queueIDs)
+    void ConnectedClient::sendQueueEntryHashMessage(
+        QList<quint32> queueIds,
+        QList<ResultOrError<QueueEntryIdsAndHash, Error>> const& entries)
     {
-        if (queueIDs.empty())
+        Q_ASSERT_X(queueIds.size() == entries.size(),
+                   "ConnectedClient::sendQueueEntryHashMessage",
+                   "list of IDs and list of results must be the same size");
+
+        if (entries.empty())
             return;
 
         const int maxSize = (1 << 16) - 1;
 
         /* not too big? */
-        if (queueIDs.size() > maxSize)
+        if (entries.size() > maxSize)
         {
             /* TODO: maybe delay the second part? */
-            sendQueueEntryInfoMessage(queueIDs.mid(0, maxSize));
-            sendQueueEntryInfoMessage(queueIDs.mid(maxSize));
+            sendQueueEntryHashMessage(queueIds.mid(0, maxSize), entries.mid(0, maxSize));
+            sendQueueEntryHashMessage(queueIds.mid(maxSize), entries.mid(maxSize));
             return;
         }
 
+        bool includeTrackId = _clientProtocolNo >= 28;
+
         QByteArray message;
-        message.reserve(4 + queueIDs.size() * (8 + NetworkProtocol::FILEHASH_BYTECOUNT));
+        message.reserve(4 + entries.size() * (8
+                                             + (includeTrackId ? 8 : 0)
+                                             + NetworkProtocol::FILEHASH_BYTECOUNT));
 
         NetworkProtocol::append2Bytes(message,
                                       ServerMessageType::BulkQueueEntryHashMessage);
-        NetworkUtil::append2Bytes(message, (uint)queueIDs.size());
+        NetworkUtil::append2BytesUnsigned(message, entries.size());
 
-        PlayerQueue& queue = _player->queue();
-
-        /* TODO: bug: concurrency issue here when a QueueEntry has just been deleted */
-
-        for (auto queueID : queueIDs)
+        for (int i = 0; i < queueIds.size(); ++i)
         {
-            auto track = queue.lookup(queueID);
-            auto trackStatus =
-                track ? createTrackStatusFor(track)
-                      : NetworkProtocol::createTrackStatusUnknownId();
+            auto queueId = queueIds[i];
+            auto& entryOrError = entries[i];
 
-            auto hash = track ? track->hash() : null;
+            quint16 trackStatus = NetworkProtocol::createTrackStatusUnknownId();
+            Nullable<FileHashWithId> hashAndId;
 
-            NetworkUtil::append4Bytes(message, queueID);
+            if (entryOrError.succeeded())
+            {
+                auto entry = entryOrError.result();
+
+                Q_ASSERT_X(queueId == entry.queueId,
+                           "ConnectedClient::sendQueueEntryHashMessage",
+                           "queue IDs do not match");
+
+                trackStatus = createTrackStatusFor(entry);
+                hashAndId = entry.hashAndId;
+            }
+
+            NetworkUtil::append4Bytes(message, queueId);
             NetworkUtil::append2Bytes(message, trackStatus);
             NetworkUtil::append2Bytes(message, 0); /* filler */
-            NetworkProtocol::appendHash(message, hash);
+
+            if (hashAndId.isNull())
+            {
+                if (includeTrackId)
+                {
+                    NetworkUtil::append8Bytes(message, 0); /* no ID */
+                }
+
+                NetworkProtocol::appendNullHash(message);
+            }
+            else
+            {
+                if (includeTrackId)
+                {
+                    NetworkUtil::append8Bytes(message, hashAndId.value().id());
+                }
+
+                NetworkProtocol::appendHash(message, hashAndId.value().hash());
+            }
         }
 
         sendBinaryMessage(message);
@@ -2041,7 +2104,7 @@ namespace PMP::Server
         }
 
         int seconds = static_cast<int>(entry->lengthInMilliseconds() / 1000);
-        auto hash = entry->hash().value();
+        auto hash = _serverInterface->getHashForTrackId(entry->trackId().value()).value();
 
         sendTextCommand(
             "nowplaying track\n QID: " + QString::number(entry->queueID())
@@ -2725,8 +2788,8 @@ namespace PMP::Server
         if (message.length() < 8 || (message.length() - 4) % 4 != 0)
             return; /* invalid message */
 
-        QList<quint32> QIDs;
-        QIDs.reserve((message.length() - 4) / 4);
+        QList<quint32> queueIds;
+        queueIds.reserve((message.length() - 4) / 4);
 
         int offset = 4;
         while (offset <= message.length() - 4)
@@ -2734,14 +2797,24 @@ namespace PMP::Server
             quint32 queueID = NetworkUtil::get4Bytes(message, offset);
 
             if (queueID > 0)
-                QIDs.append(queueID);
+                queueIds.append(queueID);
 
             offset += 4;
         }
 
-        qDebug() << "received bulk hash info request for" << QIDs.size() << "QIDs";
+        if (queueIds.size() == 1)
+        {
+            qDebug() << "received hash info request for queue ID" << queueIds[0];
+        }
+        else
+        {
+            qDebug() << "received hash info request for" << queueIds.size()
+                     << "queue IDs";
+        }
 
-        sendQueueEntryHashMessage(QIDs);
+        auto result = _serverInterface->getTrackIdAndHashForQueueIds(queueIds);
+
+        sendQueueEntryHashMessage(queueIds, result);
     }
 
     void ConnectedClient::parsePossibleFilenamesForQueueEntryRequestMessage(

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -1524,10 +1524,12 @@ namespace PMP::Server
 
         bool withAlbumAndTrackLength = _clientProtocolNo >= 7;
         bool withAlbumArtist = _clientProtocolNo >= 24;
+        bool withTrackId = _clientProtocolNo >= 28;
 
         /* estimate how much bytes we will need and reserve that memory in the buffer */
         const int bytesEstimatedPerTrack =
-            NetworkProtocol::FILEHASH_BYTECOUNT + 1 + 2 + 2 + 20 + 15
+                (withTrackId ? 8 : 0)
+                + NetworkProtocol::FILEHASH_BYTECOUNT + 1 + 2 + 2 + 20 + 15
                 + (withAlbumAndTrackLength ? 2 + 15 + 4 : 0)
                 + (withAlbumArtist ? 2 + 15 : 0);
 
@@ -1564,6 +1566,11 @@ namespace PMP::Server
             QByteArray artistData = artist.toUtf8();
             QByteArray albumData = album.toUtf8();
             QByteArray albumArtistData = albumArtist.toUtf8();
+
+            if (withTrackId)
+            {
+                NetworkUtil::append8Bytes(message, track.trackId());
+            }
 
             NetworkProtocol::appendHash(message, track.hash());
             NetworkUtil::appendByte(message, track.isAvailable() ? 1 : 0);

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -1881,6 +1881,10 @@ namespace PMP::Server
         case ResultCode::HashIsUnknown:
             sendResultMessage(ResultMessageErrorCode::InvalidHash, clientReference);
             return;
+        case ResultCode::TrackIdIsZero:
+        case ResultCode::TrackIdIsUnknown:
+            sendResultMessage(ResultMessageErrorCode::InvalidTrackId, clientReference);
+            return;
         case ResultCode::QueueEntryIdNotFound:
             sendResultMessage(ResultMessageErrorCode::QueueIdNotFound, clientReference,
                               static_cast<quint32>(result.intArg()));
@@ -2878,29 +2882,56 @@ namespace PMP::Server
     void ConnectedClient::parseAddHashToQueueRequest(const QByteArray& message,
                                                      ClientMessageType messageType)
     {
-        qDebug() << "received 'add filehash to queue' request";
+        bool canUseTrackId = _clientProtocolNo >= 28;
 
-        if (message.length() != 2 + 2 + NetworkProtocol::FILEHASH_BYTECOUNT)
-            return; /* invalid message */
-
-        bool ok;
-        FileHash hash = NetworkProtocol::getHash(message, 4, &ok);
-        if (!ok || hash.isNull())
-            return; /* invalid message */
-
-        qDebug() << " request contains hash:" << hash.dumpToString();
-
-        if (messageType == ClientMessageType::AddHashToEndOfQueueRequestMessage)
+        bool usesTrackId;
+        if (message.length() == 2 + 2 + 8 && canUseTrackId)
         {
-            _serverInterface->insertTrackAtEnd(hash);
+            usesTrackId = true;
         }
-        else if (messageType == ClientMessageType::AddHashToFrontOfQueueRequestMessage)
+        else if (message.length() == 2 + 2 + NetworkProtocol::FILEHASH_BYTECOUNT)
         {
-            _serverInterface->insertTrackAtFront(hash);
+            usesTrackId = false;
         }
         else
         {
             return; /* invalid message */
+        }
+
+        QueueInsertionPosition position;
+        if (messageType == ClientMessageType::AddHashToEndOfQueueRequestMessage)
+        {
+            position = QueueInsertionPosition::End;
+        }
+        else if (messageType == ClientMessageType::AddHashToFrontOfQueueRequestMessage)
+        {
+            position = QueueInsertionPosition::Front;
+        }
+        else
+        {
+            return; /* invalid message */
+        }
+
+        if (usesTrackId)
+        {
+            quint64 trackId = NetworkUtil::get8Bytes(message, 4);
+
+            qDebug() << "received request to add track with ID" << trackId
+                     << "to the queue at position" << position;
+
+            _serverInterface->insertTrack(position, trackId);
+        }
+        else
+        {
+            bool ok;
+            FileHash hash = NetworkProtocol::getHash(message, 4, &ok);
+            if (!ok || hash.isNull())
+                return; /* invalid message */
+
+            qDebug() << "received request to add track" << hash
+                     << "to the queue at position" << position;
+
+            _serverInterface->insertTrack(position, hash);
         }
     }
 
@@ -2940,30 +2971,56 @@ namespace PMP::Server
             sendResultMessage(result, clientReference);
     }
 
-    void ConnectedClient::parseInsertHashIntoQueueRequest(const QByteArray &message)
+    void ConnectedClient::parseInsertHashIntoQueueRequest(const QByteArray& message)
     {
-        qDebug() << "received 'insert filehash into queue at index' request";
+        bool canUseTrackId = _clientProtocolNo >= 28;
 
-        if (message.length() != 2 + 2 + 4 + 4 + NetworkProtocol::FILEHASH_BYTECOUNT)
+        bool usesTrackId;
+        if (message.length() == 2 + 2 + 4 + 4 + 8 && canUseTrackId)
+        {
+            usesTrackId = true;
+        }
+        else if (message.length() == 2 + 2 + 4 + 4 + NetworkProtocol::FILEHASH_BYTECOUNT)
+        {
+            usesTrackId = false;
+        }
+        else
+        {
             return; /* invalid message */
+        }
 
         quint32 clientReference = NetworkUtil::get4Bytes(message, 4);
         qint32 index = NetworkUtil::get4BytesSigned(message, 8);
 
-        qDebug() << " client ref:" << clientReference << "; " << "index:" << index;
+        if (usesTrackId)
+        {
+            quint64 trackId = NetworkUtil::get8Bytes(message, 12);
 
-        bool ok;
-        FileHash hash = NetworkProtocol::getHash(message, 12, &ok);
-        if (!ok || hash.isNull())
-            return; /* invalid message */
+            qDebug() << "received request to add track with ID" << trackId
+                     << "to the queue at index" << index << "; ref:" << clientReference;
 
-        qDebug() << " request contains hash:" << hash.dumpToString();
+            auto result = _serverInterface->insertTrack(trackId, index, clientReference);
 
-        auto result = _serverInterface->insertTrack(hash, index, clientReference);
+            /* success is handled by the queue insertion event, failure is handled here */
+            if (!result)
+                sendResultMessage(result, clientReference);
+        }
+        else
+        {
+            bool ok;
+            FileHash hash = NetworkProtocol::getHash(message, 12, &ok);
+            if (!ok || hash.isNull())
+                return; /* invalid message */
 
-        /* success is handled by the queue insertion event, failure is handled here */
-        if (!result)
-            sendResultMessage(result, clientReference);
+            qDebug() << "received request to add track" << hash
+                     << "to the queue at index" << index << "; ref:" << clientReference;
+
+            auto result = _serverInterface->insertTrack(hash, index, clientReference);
+
+            /* success is handled by the queue insertion event, failure is handled here */
+            if (!result)
+                sendResultMessage(result, clientReference);
+        }
     }
 
     void ConnectedClient::parseQueueEntryRemovalRequest(QByteArray const& message)

--- a/src/server/connectedclient.cpp
+++ b/src/server/connectedclient.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -45,7 +45,7 @@ namespace PMP::Server
 {
     /* ====================== ConnectedClient ====================== */
 
-    const qint16 ConnectedClient::ServerProtocolNo = 27;
+    const qint16 ConnectedClient::ServerProtocolNo = 28;
 
     ConnectedClient::ConnectedClient(QTcpSocket* socket, ServerInterface* serverInterface,
                                      Player* player,
@@ -1031,6 +1031,8 @@ namespace PMP::Server
     void ConnectedClient::sendHashInfoReply(uint clientReference,
                                             CollectionTrackInfo info)
     {
+        bool includeTrackId = _clientProtocolNo >= 28;
+
         QString title = info.title();
         QString artist = info.artist();
         QString album = info.album();
@@ -1049,13 +1051,19 @@ namespace PMP::Server
         QByteArray albumArtistData = albumArtist.toUtf8();
 
         QByteArray message;
-        message.reserve(2 + 2 + 4 + 4 * 2 + 4
+        message.reserve(2 + 2 + 4 + (includeTrackId ? 8 : 0) + 4 * 2 + 4
                         + titleData.size() + artistData.size() + albumData.size()
                         + albumArtistData.size());
         NetworkProtocol::append2Bytes(message, ServerMessageType::HashInfoReply);
         NetworkUtil::appendByte(message, 0); // filler
         NetworkUtil::appendByte(message, info.isAvailable() ? 1 : 0);
         NetworkUtil::append4Bytes(message, clientReference);
+
+        if (includeTrackId)
+        {
+            NetworkUtil::append8Bytes(message, info.hashId());
+        }
+
         NetworkUtil::append2BytesUnsigned(message, titleData.size());
         NetworkUtil::append2BytesUnsigned(message, artistData.size());
         NetworkUtil::append2BytesUnsigned(message, albumData.size());
@@ -1381,8 +1389,9 @@ namespace PMP::Server
         sendTrackInfoBatchMessage(clientReference, false, tracks);
     }
 
-    void ConnectedClient::sendTrackAvailabilityBatchMessage(QVector<FileHash> available,
-                                                            QVector<FileHash> unavailable)
+    void ConnectedClient::sendTrackAvailabilityBatchMessage(
+                                                    QVector<FileHashWithId> available,
+                                                    QVector<FileHashWithId> unavailable)
     {
         if (_clientProtocolNo < 11) /* only send this if the client will understand */
             return;
@@ -1422,12 +1431,12 @@ namespace PMP::Server
 
         for (int i = 0; i < available.size(); ++i)
         {
-            NetworkProtocol::appendHash(message, available[i]);
+            NetworkProtocol::appendHash(message, available[i].hash());
         }
 
         for (int i = 0; i < unavailable.size(); ++i)
         {
-            NetworkProtocol::appendHash(message, unavailable[i]);
+            NetworkProtocol::appendHash(message, unavailable[i].hash());
         }
 
         sendBinaryMessage(message);
@@ -1563,8 +1572,8 @@ namespace PMP::Server
         sendScrobblingProviderEnabledChangeMessage(userId, provider, enabled);
     }
 
-    void ConnectedClient::onHashAvailabilityChanged(QVector<FileHash> available,
-                                                    QVector<FileHash> unavailable)
+    void ConnectedClient::onHashAvailabilityChanged(QVector<FileHashWithId> available,
+                                                    QVector<FileHashWithId> unavailable)
     {
         sendTrackAvailabilityBatchMessage(available, unavailable);
     }

--- a/src/server/connectedclient.h
+++ b/src/server/connectedclient.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -28,6 +28,7 @@
 #include "common/startstopeventstatus.h"
 
 #include "collectiontrackinfo.h"
+#include "filehashwithid.h"
 #include "hashstats.h"
 #include "historyentry.h"
 #include "recenthistoryentry.h"
@@ -106,8 +107,8 @@ namespace PMP::Server
         void onCollectionTrackInfoBatchToSend(uint clientReference,
                                               QVector<CollectionTrackInfo> tracks);
         void onCollectionTrackInfoCompleted(uint clientReference);
-        void onHashAvailabilityChanged(QVector<PMP::FileHash> available,
-                                       QVector<PMP::FileHash> unavailable);
+        void onHashAvailabilityChanged(QVector<PMP::Server::FileHashWithId> available,
+                                       QVector<PMP::Server::FileHashWithId> unavailable);
         void onHashInfoChanged(QVector<CollectionTrackInfo> changes);
 
         void onScrobblingProviderInfo(ScrobblingProvider provider, ScrobblerStatus status,
@@ -181,8 +182,8 @@ namespace PMP::Server
         void sendNonFatalInternalErrorResultMessage(quint32 clientReference);
         void sendUserLoginSaltMessage(QString login, QByteArray const& userSalt,
                                       QByteArray const& sessionSalt);
-        void sendTrackAvailabilityBatchMessage(QVector<FileHash> available,
-                                               QVector<FileHash> unavailable);
+        void sendTrackAvailabilityBatchMessage(QVector<FileHashWithId> available,
+                                               QVector<FileHashWithId> unavailable);
         void sendTrackInfoBatchMessage(uint clientReference, bool isNotification,
                                        QVector<CollectionTrackInfo> tracks);
         void sendNewHistoryEntryMessage(QSharedPointer<RecentHistoryEntry> entry);

--- a/src/server/connectedclient.h
+++ b/src/server/connectedclient.h
@@ -23,6 +23,7 @@
 #include "common/filehash.h"
 #include "common/networkprotocol.h"
 #include "common/networkprotocolextensions.h"
+#include "common/resultorerror.h"
 #include "common/scrobblerstatus.h"
 #include "common/scrobblingprovider.h"
 #include "common/startstopeventstatus.h"
@@ -31,6 +32,7 @@
 #include "filehashwithid.h"
 #include "hashstats.h"
 #include "historyentry.h"
+#include "queueentryidsandhash.h"
 #include "recenthistoryentry.h"
 #include "result.h"
 #include "serverplayerstate.h"
@@ -159,7 +161,9 @@ namespace PMP::Server
                                         quint32 queueID);
         void sendQueueEntryInfoMessage(quint32 queueID);
         void sendQueueEntryInfoMessage(QList<quint32> const& queueIDs);
-        void sendQueueEntryHashMessage(QList<quint32> const& queueIDs);
+        void sendQueueEntryHashMessage(QList<quint32> queueIds,
+                        QList<ResultOrError<QueueEntryIdsAndHash, Error>> const& hashes);
+        quint16 createTrackStatusFor(QueueEntryIdsAndHash const& entry);
         quint16 createTrackStatusFor(QSharedPointer<QueueEntry> entry);
         void sendPossibleTrackFilenames(quint32 queueID, QVector<QString> const& names);
         void sendNewUserAccountSaltMessage(QString login, QByteArray const& salt);

--- a/src/server/filehashwithid.h
+++ b/src/server/filehashwithid.h
@@ -28,7 +28,7 @@ namespace PMP::Server
     {
     public:
         FileHashWithId() : _id(0) {}
-        FileHashWithId(FileHash hash, uint hashId) : _hash(hash), _id(hashId) {}
+        FileHashWithId(FileHash hash, uint trackId) : _hash(hash), _id(trackId) {}
 
         FileHash const& hash() const { return _hash; }
         uint id() const { return _id; }

--- a/src/server/filehashwithid.h
+++ b/src/server/filehashwithid.h
@@ -1,0 +1,75 @@
+/*
+    Copyright (C) 2025, Kevin André <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_SERVER_FILEHASHWITHID_H
+#define PMP_SERVER_FILEHASHWITHID_H
+
+#include "common/filehash.h"
+
+namespace PMP::Server
+{
+    class FileHashWithId
+    {
+    public:
+        FileHashWithId() : _id(0) {}
+        FileHashWithId(FileHash hash, uint hashId) : _hash(hash), _id(hashId) {}
+
+        FileHash const& hash() const { return _hash; }
+        uint id() const { return _id; }
+
+        auto operator<=>(const FileHashWithId& other) const = default;
+
+    private:
+        FileHash _hash;
+        uint _id;
+    };
+
+    inline size_t qHash(const FileHashWithId& hashWithId, size_t seed)
+    {
+        auto const& hash = hashWithId.hash();
+
+        return qHashMulti(seed, hash.length(), hash.SHA1(), hash.MD5(), hashWithId.id());
+    }
+
+    inline QDebug operator<<(QDebug debug, const FileHashWithId& hashWithId)
+    {
+        auto const& hash = hashWithId.hash();
+
+        QString output;
+
+        if (hash.isNull())
+        {
+            output += "(null hash)";
+        }
+        else
+        {
+            output += hash.toString();
+        }
+
+        output += "/ID";
+        output += QString::number(hashWithId.id());
+
+        debug << output;
+        return debug;
+    }
+}
+
+Q_DECLARE_METATYPE(PMP::Server::FileHashWithId)
+
+#endif

--- a/src/server/hashidregistrar.cpp
+++ b/src/server/hashidregistrar.cpp
@@ -184,7 +184,10 @@ namespace PMP::Server
 
     bool HashIdRegistrar::isRegisteredHash(FileHash hash)
     {
-        return getIdForHash(hash).hasValue();
+        QMutexLocker lock(&_mutex);
+
+        auto it = _hashes.constFind(hash);
+        return it != _hashes.constEnd();
     }
 
     bool HashIdRegistrar::isRegisteredId(uint id)

--- a/src/server/hashidregistrar.cpp
+++ b/src/server/hashidregistrar.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -182,9 +182,17 @@ namespace PMP::Server
         return it.value();
     }
 
-    bool HashIdRegistrar::isRegistered(FileHash hash)
+    bool HashIdRegistrar::isRegisteredHash(FileHash hash)
     {
         return getIdForHash(hash).hasValue();
+    }
+
+    bool HashIdRegistrar::isRegisteredId(uint id)
+    {
+        QMutexLocker lock(&_mutex);
+
+        auto it = _ids.constFind(id);
+        return it != _ids.constEnd();
     }
 
     Nullable<FileHash> HashIdRegistrar::getHashForId(uint id)

--- a/src/server/hashidregistrar.h
+++ b/src/server/hashidregistrar.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2022-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2022-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -44,7 +44,8 @@ namespace PMP::Server
         QList<uint> getAllIdsLoaded();
         QVector<QPair<uint, FileHash>> getExistingIdsOnly(QVector<FileHash> hashes);
         Nullable<uint> getIdForHash(FileHash hash);
-        bool isRegistered(FileHash hash);
+        bool isRegisteredHash(FileHash hash);
+        bool isRegisteredId(uint id);
         Nullable<FileHash> getHashForId(uint id);
 
     private:

--- a/src/server/history.cpp
+++ b/src/server/history.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -19,7 +19,6 @@
 
 #include "history.h"
 
-#include "hashidregistrar.h"
 #include "historystatistics.h"
 #include "player.h"
 #include "queueentry.h"
@@ -30,10 +29,8 @@
 
 namespace PMP::Server
 {
-    History::History(Player* player, HashIdRegistrar* hashIdRegistrar,
-                     HistoryStatistics* historyStatistics)
+    History::History(Player* player, HistoryStatistics* historyStatistics)
      : _player(player),
-       _hashIdRegistrar(hashIdRegistrar),
        _statistics(historyStatistics),
        _nowPlaying(nullptr)
     {
@@ -56,44 +53,44 @@ namespace PMP::Server
         //
     }
 
-    QDateTime History::lastPlayedGloballySinceStartup(FileHash const& hash) const
+    QDateTime History::lastPlayedGloballySinceStartup(uint trackId) const
     {
-        return _lastPlayHash[hash];
+        return _lastPlayByTrack[trackId];
     }
 
     Future<SuccessType, FailureType> History::scheduleUserStatsFetchingIfMissing(
-                                                                           uint hashId,
+                                                                           uint trackId,
                                                                            quint32 userId)
     {
-        if (hashId == 0)
+        if (trackId == 0)
         {
-            qWarning() << "History: invalid parameter(s): hashId" << hashId
-                       << "user" << userId;
+            qWarning() << "History: invalid parameter(s): track ID" << trackId
+                       << " user ID" << userId;
             return FutureError(failure);
         }
 
-        return _statistics->scheduleFetchIfMissing(userId, hashId);
+        return _statistics->scheduleFetchIfMissing(userId, trackId);
     }
 
-    Nullable<TrackStats> History::getUserStats(uint hashId, quint32 userId)
+    Nullable<TrackStats> History::getUserStats(uint trackId, quint32 userId)
     {
-        if (hashId == 0)
+        if (trackId == 0)
         {
-            qWarning() << "History: got request for user stats of hash ID zero";
+            qWarning() << "History: got request for user stats of track ID zero";
             return null;
         }
 
-        return _statistics->getStatsIfAvailable(userId, hashId);
+        return _statistics->getStatsIfAvailable(userId, trackId);
     }
 
     void History::currentTrackChanged(QSharedPointer<QueueEntry const> newTrack)
     {
         if (_nowPlaying != nullptr && newTrack != _nowPlaying)
         {
-            Nullable<FileHash> hash = _nowPlaying->hash();
-            if (hash.hasValue())
+            Nullable<uint> trackId = _nowPlaying->trackId();
+            if (trackId.hasValue())
             {
-                _lastPlayHash[hash.value()] = QDateTime::currentDateTimeUtc();
+                _lastPlayByTrack[trackId.value()] = QDateTime::currentDateTimeUtc();
             }
         }
 
@@ -105,31 +102,8 @@ namespace PMP::Server
         if (entry->permillage() <= 0 && entry->hadError())
             return;
 
-        FileHash hash = entry->hash();
-        if (hash.isNull())
-        {
-            qWarning() << "cannot save history for queue ID" << entry->queueID()
-                       << "because hash is unavailabe";
-            return;
-        }
-
-        auto* statistics = _statistics;
-
-        _hashIdRegistrar->getOrCreateId(hash)
-            .thenOnAnyThreadIndirect<SuccessType, FailureType>(
-                [statistics, entry](FailureOr<uint> outcome)
-                    -> Future<SuccessType, FailureType>
-                {
-                    if (outcome.failed())
-                        return FutureError(failure);
-
-                    auto hashId = outcome.result();
-                    uint userId = entry->user();
-
-                    return statistics->addToHistory(userId, hashId, entry->started(),
-                                                    entry->ended(), entry->permillage(),
-                                                    entry->validForScoring());
-                }
-            );
+        _statistics->addToHistory(entry->user(), entry->trackId(),
+                                  entry->started(), entry->ended(), entry->permillage(),
+                                  entry->validForScoring());
     }
 }

--- a/src/server/history.h
+++ b/src/server/history.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -20,7 +20,6 @@
 #ifndef PMP_HISTORY_H
 #define PMP_HISTORY_H
 
-#include "common/filehash.h"
 #include "common/future.h"
 #include "common/nullable.h"
 
@@ -36,7 +35,6 @@ QT_FORWARD_DECLARE_CLASS(QThreadPool)
 
 namespace PMP::Server
 {
-    class HashIdRegistrar;
     class HistoryStatistics;
     class Player;
     class QueueEntry;
@@ -45,18 +43,17 @@ namespace PMP::Server
     {
         Q_OBJECT
     public:
-        History(Player* player, HashIdRegistrar* hashIdRegistrar,
-                HistoryStatistics* historyStatistics);
+        History(Player* player, HistoryStatistics* historyStatistics);
 
         ~History();
 
         /** Get last played time since server startup (non-user-specific) */
-        QDateTime lastPlayedGloballySinceStartup(FileHash const& hash) const;
+        QDateTime lastPlayedGloballySinceStartup(uint trackId) const;
 
         Future<SuccessType, FailureType> scheduleUserStatsFetchingIfMissing(
-                                                                        uint hashId,
+                                                                        uint trackId,
                                                                         quint32 userId);
-        Nullable<TrackStats> getUserStats(uint hashId, quint32 userId);
+        Nullable<TrackStats> getUserStats(uint trackId, quint32 userId);
 
     Q_SIGNALS:
         void hashStatisticsChanged(quint32 userId, QVector<uint> hashIds);
@@ -67,9 +64,8 @@ namespace PMP::Server
 
     private:
         Player* _player;
-        HashIdRegistrar* _hashIdRegistrar;
         HistoryStatistics* _statistics;
-        QHash<FileHash, QDateTime> _lastPlayHash;
+        QHash<uint, QDateTime> _lastPlayByTrack;
         QSharedPointer<QueueEntry const> _nowPlaying;
     };
 }

--- a/src/server/historyentry.h
+++ b/src/server/historyentry.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -31,14 +31,17 @@ namespace PMP::Server
     class HistoryEntry
     {
     public:
-        HistoryEntry(FileHash hash, uint user, QDateTime started, QDateTime ended,
+        HistoryEntry(uint trackId, FileHash hash, uint user,
+                     QDateTime started, QDateTime ended,
                      int permillage, bool validForScoring)
-         : _hash(hash), _user(user), _started(started), _ended(ended),
+         : _trackId(trackId), _hash(hash), _user(user),
+           _started(started), _ended(ended),
            _permillage(permillage), _validForScoring(validForScoring)
         {
             //
         }
 
+        uint trackId() const { return _trackId; }
         FileHash hash() const { return _hash; }
         uint userId() const { return _user; }
         QDateTime started() const { return _started; }
@@ -47,6 +50,7 @@ namespace PMP::Server
         int permillage() const { return _permillage; }
 
     private:
+        uint _trackId;
         FileHash _hash;
         uint _user;
         QDateTime _started;

--- a/src/server/lastfmscrobblingbackend.cpp
+++ b/src/server/lastfmscrobblingbackend.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2018-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2018-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -227,12 +227,12 @@ namespace PMP::Server
                                                           LastFmScrobblingBackend* parent,
                                                               QNetworkReply* pendingReply)
      : LastFmRequestHandler(parent, pendingReply, "session"),
-        _promise(Async::createPromise<LastFmAuthenticationResult, Result>())
+        _promise(Async::createPromise<LastFmAuthenticationResult, Error>())
     {
         //
     }
 
-    Future<LastFmAuthenticationResult, Result>
+    Future<LastFmAuthenticationResult, Error>
         LastFmAuthenticationRequestHandler::future() const
     {
         return _promise.future();
@@ -426,11 +426,11 @@ namespace PMP::Server
 
         return
             handler->future()
-                .thenOnEventLoop<SuccessType, Result>(
+                .thenOnEventLoop<SuccessType, Error>(
                     this,
                     [this, usernameOrEmail](
-                        ResultOrError<LastFmAuthenticationResult, Result> outcome)
-                            -> ResultOrError<SuccessType, Result>
+                        ResultOrError<LastFmAuthenticationResult, Error> outcome)
+                            -> ResultOrError<SuccessType, Error>
                     {
                         if (outcome.failed())
                         {
@@ -448,7 +448,7 @@ namespace PMP::Server
                 )
                 .convertToSimpleFuture<Result>(
                     [](SuccessType const&) -> Result { return Success(); },
-                    [](Result const& result) { return result; }
+                    [](Error const& error) { return error; }
                 );
     }
 

--- a/src/server/lastfmscrobblingbackend.h
+++ b/src/server/lastfmscrobblingbackend.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2018-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2018-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -87,7 +87,7 @@ namespace PMP::Server
         LastFmAuthenticationRequestHandler(LastFmScrobblingBackend* parent,
                                            QNetworkReply* pendingReply);
 
-        Future<LastFmAuthenticationResult, Result> future() const;
+        Future<LastFmAuthenticationResult, Error> future() const;
 
     protected:
         void handleOkReply(const QDomElement& childElement) override;
@@ -95,7 +95,7 @@ namespace PMP::Server
         void onGenericError() override;
 
     private:
-        Promise<LastFmAuthenticationResult, Result> _promise;
+        Promise<LastFmAuthenticationResult, Error> _promise;
     };
 
     class LastFmNowPlayingRequestHandler : public LastFmRequestHandler

--- a/src/server/player.cpp
+++ b/src/server/player.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -146,7 +146,7 @@ namespace PMP::Server
 
             if (!filename.isEmpty())
             {
-                if (_resolver->pathStillValid(queueEntry->hash().value(), filename))
+                if (_resolver->pathStillValid(queueEntry->trackId().value(), filename))
                 {
                     qWarning() << "queue ID" << queueId << "was not preloaded; "
                                   "will try to use unpreprocessed file that may be slow "
@@ -312,7 +312,8 @@ namespace PMP::Server
 
     /* ================================================================================ */
 
-    Player::Player(QObject* parent, Resolver* resolver, int defaultVolume)
+    Player::Player(QObject* parent, HashIdRegistrar* hashIdRegistrar, Resolver* resolver,
+                   int defaultVolume)
      : QObject(parent),
        _audioDevices(new AudioDevices(this)),
        _oldInstance1(nullptr),
@@ -320,7 +321,7 @@ namespace PMP::Server
        _currentInstance(nullptr),
        _nextInstance(nullptr),
        _resolver(resolver),
-       _queue(resolver), _preloader(nullptr, &_queue, resolver),
+       _queue(hashIdRegistrar, resolver), _preloader(nullptr, &_queue, resolver),
        _nowPlaying(nullptr),
        _instanceIdentifier(0),
        _volume(-1),
@@ -887,6 +888,8 @@ namespace PMP::Server
         if (!entry->isTrack())
             return; /* don't put breakpoints in the history */
 
+        auto trackId = entry->trackId().value();
+
         if (_historyOrder.isEmpty())
         {
             qWarning()
@@ -916,11 +919,9 @@ namespace PMP::Server
                 ended = started;
         }
 
-        Nullable<FileHash> hash = entry->hash();
-
         auto historyEntry =
             QSharedPointer<RecentHistoryEntry>::create(
-                queueID, hash.value(), userPlayedFor, started, ended,
+                queueID, trackId, userPlayedFor, started, ended,
                 hadError, hadSeek, permillage
             );
 

--- a/src/server/player.h
+++ b/src/server/player.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -35,6 +35,7 @@ QT_FORWARD_DECLARE_CLASS(QMediaPlayer);
 namespace PMP::Server
 {
     class AudioDevices;
+    class HashIdRegistrar;
     class Resolver;
 
     class PlayerInstance : public QObject
@@ -102,7 +103,8 @@ namespace PMP::Server
     {
         Q_OBJECT
     public:
-        Player(QObject* parent, Resolver* resolver, int defaultVolume);
+        Player(QObject* parent, HashIdRegistrar* hashIdRegistrar, Resolver* resolver,
+               int defaultVolume);
 
         int volume() const;
 

--- a/src/server/playerqueue.cpp
+++ b/src/server/playerqueue.cpp
@@ -115,6 +115,14 @@ namespace PMP::Server
         }
     }
 
+    int PlayerQueue::toIndex(QueueInsertionPosition position)
+    {
+        if (position == QueueInsertionPosition::Front)
+            return 0;
+        else //if (position == QueueInsertionPosition::End)
+            return _queue.length();
+    }
+
     bool PlayerQueue::empty() const
     {
         return _queue.empty();
@@ -225,48 +233,32 @@ namespace PMP::Server
             };
     }
 
-    Result PlayerQueue::enqueue(FileHash hash)
+    Result PlayerQueue::enqueue(uint trackId)
     {
-        if (hash.isNull())
-            return Error::hashIsNull();
-
-        auto trackId = _hashIdRegistrar->getIdForHash(hash);
-        if (trackId == null)
-            return Error::hashIsUnknown();
-
-        return enqueue(QueueEntryCreators::track(trackId.value()));
+        return insertTrack(QueueInsertionPosition::End, trackId);
     }
 
-    Result PlayerQueue::enqueue(
-                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator)
+    Result PlayerQueue::enqueue(FileHash hash)
     {
-        return insertAtIndex(_queue.length(), queueEntryCreator);
+        return insertTrack(QueueInsertionPosition::End, hash);
+    }
+
+    Result PlayerQueue::insertAtFront(uint trackId)
+    {
+        return insertTrack(QueueInsertionPosition::Front, trackId);
     }
 
     Result PlayerQueue::insertAtFront(FileHash hash)
     {
-        if (hash.isNull())
-            return Error::hashIsNull();
-
-        auto trackId = _hashIdRegistrar->getIdForHash(hash);
-        if (trackId == null)
-            return Error::hashIsUnknown();
-
-        return insertAtFront(QueueEntryCreators::track(trackId.value()));
+        return insertTrack(QueueInsertionPosition::Front, hash);
     }
 
     Result PlayerQueue::insertBreakAtFront()
     {
-        return insertAtFront(QueueEntryCreators::breakpoint());
+        return insertAtIndex(0, QueueEntryCreators::breakpoint());
     }
 
-    Result PlayerQueue::insertAtFront(
-                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator)
-    {
-        return insertAtIndex(0, queueEntryCreator);
-    }
-
-    Result PlayerQueue::insertAtIndex(qint32 index, FileHash hash)
+    Result PlayerQueue::insertTrack(QueueInsertionPosition position, FileHash hash)
     {
         if (hash.isNull())
             return Error::hashIsNull();
@@ -275,7 +267,22 @@ namespace PMP::Server
         if (trackId == null)
             return Error::hashIsUnknown();
 
+        auto index = toIndex(position);
+
         return insertAtIndex(index, QueueEntryCreators::track(trackId.value()));
+    }
+
+    Result PlayerQueue::insertTrack(QueueInsertionPosition position, uint trackId)
+    {
+        if (trackId == 0)
+            return Error::trackIdIsZero();
+
+        if (_hashIdRegistrar->isRegisteredId(trackId) == false)
+            return Error::trackIdIsUnknown();
+
+        auto index = toIndex(position);
+
+        return insertAtIndex(index, QueueEntryCreators::track(trackId));
     }
 
     Result PlayerQueue::insertAtIndex(qint32 index,
@@ -304,6 +311,54 @@ namespace PMP::Server
         }
 
         return insertAtIndex(index, queueEntryCreator, queueIdNotifier);
+    }
+
+    Result PlayerQueue::insertAtIndex(qint32 index, uint trackId,
+                                      std::function<void (uint)> queueIdNotifier)
+    {
+        if (trackId == 0)
+            return Error::trackIdIsZero();
+
+        if (_hashIdRegistrar->isRegisteredId(trackId) == false)
+            return Error::trackIdIsUnknown();
+
+        auto entryCreator = QueueEntryCreators::track(trackId);
+
+        return insertAtIndex(index, entryCreator, queueIdNotifier);
+    }
+
+    Result PlayerQueue::insertAtIndex(qint32 index, FileHash hash,
+                                      std::function<void (uint)> queueIdNotifier)
+    {
+        if (hash.isNull())
+            return Error::hashIsNull();
+
+        auto trackId = _hashIdRegistrar->getIdForHash(hash);
+        if (trackId == null)
+            return Error::hashIsUnknown();
+
+        auto entryCreator = QueueEntryCreators::track(trackId.value());
+
+        return insertAtIndex(index, entryCreator, queueIdNotifier);
+    }
+
+    Result PlayerQueue::duplicateEntryWithId(uint queueId,
+                                             std::function<void (uint)> queueIdNotifier)
+    {
+        auto index = findIndex(queueId);
+        if (index < 0)
+            return Error::queueEntryIdNotFound(queueId);
+
+        auto existing = _queue.at(index);
+        if (existing->queueID() != queueId)
+        {
+            qWarning() << "queue inconsistency for QID" << queueId;
+            return Error::internalError();
+        }
+
+        auto entryCreator = QueueEntryCreators::copyOf(existing);
+
+        return insertAtIndex(index + 1, entryCreator, queueIdNotifier);
     }
 
     Result PlayerQueue::insertAtIndex(qint32 index,

--- a/src/server/playerqueue.cpp
+++ b/src/server/playerqueue.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -19,6 +19,7 @@
 
 #include "playerqueue.h"
 
+#include "hashidregistrar.h"
 #include "queueentry.h"
 #include "resolver.h"
 
@@ -33,9 +34,10 @@ namespace PMP::Server
         const int maximumQueueLength = 2'000'000;
     }
 
-    PlayerQueue::PlayerQueue(Resolver* resolver)
-     : _nextQueueID(1), _firstTrackIndex(-1), _firstTrackQueueId(0),
-       _resolver(resolver), _queueFrontChecker(new QTimer(this))
+    PlayerQueue::PlayerQueue(HashIdRegistrar* hashIdRegistrar, Resolver* resolver)
+     : _hashIdRegistrar(hashIdRegistrar), _resolver(resolver),
+        _queueFrontChecker(new QTimer(this)),
+        _nextQueueID(1), _firstTrackIndex(-1), _firstTrackQueueId(0)
     {
         connect(
             _queueFrontChecker, &QTimer::timeout,
@@ -56,9 +58,10 @@ namespace PMP::Server
             if (!entry->isTrack())
                 continue;
 
-            auto hash = entry->hash().value();
+            auto trackId = entry->trackId().value();
             auto filename = entry->filename();
-            if (filename.hasValue() && !_resolver->pathStillValid(hash, filename.value()))
+            if (filename.hasValue()
+                && !_resolver->pathStillValid(trackId, filename.value()))
             {
                 qDebug() << "PlayerQueue: filename no longer valid for queue index"
                          << (index + 1);
@@ -82,10 +85,10 @@ namespace PMP::Server
 
             qDebug() << "PlayerQueue: need to obtain a valid filename for queue index"
                      << (index + 1) << "which has queue ID" << entry->queueID()
-                     << "and hash" << hash;
+                     << "and track ID" << trackId;
 
             backoff = 10;
-            auto future = _resolver->findPathForHashAsync(hash);
+            auto future = _resolver->findPathForTrackAsync(trackId);
             future.handleOnEventLoop(
                 this,
                 [entry, index](FailureOr<QString> outcome)
@@ -180,12 +183,58 @@ namespace PMP::Server
         }
     }
 
+    QList<ResultOrError<QueueEntryIdsAndHash, class Error>>
+        PlayerQueue::getHashAndTrackIdForQueueIds(QList<uint> queueIds) const
+    {
+        QList<ResultOrError<QueueEntryIdsAndHash, class Error>> result;
+        result.reserve(queueIds.size());
+
+        for (auto queueId : queueIds)
+        {
+            auto it = _idLookup.find(queueId);
+            if (it == _idLookup.constEnd())
+            {
+                result.append(Error::queueEntryIdNotFound(queueId));
+                continue;
+            }
+
+            result.append(toQueueEntryIdsAndHash(it.value()));
+        }
+
+        return result;
+    }
+
+    QueueEntryIdsAndHash PlayerQueue::toQueueEntryIdsAndHash(
+        QSharedPointer<QueueEntry> entry) const
+    {
+        Nullable<FileHashWithId> hashAndId;
+
+        if (entry->isTrack())
+        {
+            auto trackId = entry->trackId().value();
+            auto hash = _hashIdRegistrar->getHashForId(trackId).value();
+
+            hashAndId = FileHashWithId(hash, trackId);
+        }
+
+        return
+            {
+                .queueId = entry->queueID(),
+                .kind = entry->kind(),
+                .hashAndId = hashAndId,
+            };
+    }
+
     Result PlayerQueue::enqueue(FileHash hash)
     {
         if (hash.isNull())
             return Error::hashIsNull();
 
-        return enqueue(QueueEntryCreators::hash(hash));
+        auto trackId = _hashIdRegistrar->getIdForHash(hash);
+        if (trackId == null)
+            return Error::hashIsUnknown();
+
+        return enqueue(QueueEntryCreators::track(trackId.value()));
     }
 
     Result PlayerQueue::enqueue(
@@ -199,7 +248,11 @@ namespace PMP::Server
         if (hash.isNull())
             return Error::hashIsNull();
 
-        return insertAtFront(QueueEntryCreators::hash(hash));
+        auto trackId = _hashIdRegistrar->getIdForHash(hash);
+        if (trackId == null)
+            return Error::hashIsUnknown();
+
+        return insertAtFront(QueueEntryCreators::track(trackId.value()));
     }
 
     Result PlayerQueue::insertBreakAtFront()
@@ -218,7 +271,11 @@ namespace PMP::Server
         if (hash.isNull())
             return Error::hashIsNull();
 
-        return insertAtIndex(index, QueueEntryCreators::hash(hash));
+        auto trackId = _hashIdRegistrar->getIdForHash(hash);
+        if (trackId == null)
+            return Error::hashIsUnknown();
+
+        return insertAtIndex(index, QueueEntryCreators::track(trackId.value()));
     }
 
     Result PlayerQueue::insertAtIndex(qint32 index,
@@ -512,7 +569,7 @@ namespace PMP::Server
         return -1; // not found
     }
 
-    TrackRepetitionInfo PlayerQueue::checkPotentialRepetitionByAdd(FileHash hash,
+    TrackRepetitionInfo PlayerQueue::checkPotentialRepetitionByAdd(uint trackId,
                                                      int repetitionAvoidanceSeconds,
                                                      qint64 extraMarginMilliseconds) const
     {
@@ -524,9 +581,9 @@ namespace PMP::Server
             if (!entry->isTrack())
                 continue;
 
-            auto entryHash = entry->hash().value();
+            auto entryTrackId = entry->trackId().value();
 
-            if (entryHash == hash)
+            if (entryTrackId == trackId)
                 return TrackRepetitionInfo(true, millisecondsCounted);
 
             entry->checkAudioData(*_resolver);
@@ -545,5 +602,4 @@ namespace PMP::Server
 
         return TrackRepetitionInfo(false, millisecondsCounted);
     }
-
 }

--- a/src/server/playerqueue.h
+++ b/src/server/playerqueue.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,8 +21,10 @@
 #define PMP_PLAYERQUEUE_H
 
 #include "common/filehash.h"
+#include "common/resultorerror.h"
 #include "common/specialqueueitemtype.h"
 
+#include "queueentryidsandhash.h"
 #include "recenthistoryentry.h"
 #include "result.h"
 
@@ -43,6 +45,7 @@ namespace PMP
 
 namespace PMP::Server
 {
+    class HashIdRegistrar;
     class RecentHistoryEntry;
     class QueueEntry;
     class Resolver;
@@ -73,9 +76,9 @@ namespace PMP::Server
             Played, Skipped, Error
         };
 
-        PlayerQueue(Resolver* resolver);
+        PlayerQueue(HashIdRegistrar* hashIdRegistrar, Resolver* resolver);
 
-        TrackRepetitionInfo checkPotentialRepetitionByAdd(FileHash hash,
+        TrackRepetitionInfo checkPotentialRepetitionByAdd(uint trackId,
                                                           int repetitionAvoidanceSeconds,
                                                           qint64 extraMarginMilliseconds
                                                           ) const;
@@ -96,6 +99,9 @@ namespace PMP::Server
         int findIndex(quint32 queueID);
         QSharedPointer<QueueEntry> entryAtIndex(int index) const;
         QList<QSharedPointer<QueueEntry>> entries(int startoffset, int maxCount);
+
+        QList<ResultOrError<QueueEntryIdsAndHash, class Error>>
+            getHashAndTrackIdForQueueIds(QList<uint> queueIds) const;
 
         Result enqueue(FileHash hash);
         Result enqueue(std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator);
@@ -139,19 +145,21 @@ namespace PMP::Server
         void checkFrontOfQueue();
 
     private:
+        QueueEntryIdsAndHash toQueueEntryIdsAndHash(QSharedPointer<QueueEntry>) const;
         void resetFirstTrack();
         void setFirstTrackIndexAndId(int index, uint queueId);
         void findFirstTrackBetweenIndices(int start, int end, bool resetIfNoneFound);
         void emitFirstTrackChanged();
 
+        HashIdRegistrar* _hashIdRegistrar;
+        Resolver* _resolver;
+        QTimer* _queueFrontChecker;
         uint _nextQueueID;
         int _firstTrackIndex;
         uint _firstTrackQueueId;
         QHash<quint32, QSharedPointer<QueueEntry>> _idLookup;
         QQueue<QSharedPointer<QueueEntry>> _queue;
         QQueue<QSharedPointer<RecentHistoryEntry>> _history;
-        Resolver* _resolver;
-        QTimer* _queueFrontChecker;
     };
 }
 #endif

--- a/src/server/playerqueue.h
+++ b/src/server/playerqueue.h
@@ -25,6 +25,7 @@
 #include "common/specialqueueitemtype.h"
 
 #include "queueentryidsandhash.h"
+#include "queueinsertionposition.h"
 #include "recenthistoryentry.h"
 #include "result.h"
 
@@ -103,22 +104,25 @@ namespace PMP::Server
         QList<ResultOrError<QueueEntryIdsAndHash, class Error>>
             getHashAndTrackIdForQueueIds(QList<uint> queueIds) const;
 
+        Result enqueue(uint trackId);
         Result enqueue(FileHash hash);
-        Result enqueue(std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator);
 
+        Result insertAtFront(uint trackId);
         Result insertAtFront(FileHash hash);
         Result insertBreakAtFront();
-        Result insertAtFront(
-                      std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator);
 
-        Result insertAtIndex(qint32 index, FileHash hash);
-        Result insertAtIndex(qint32 index,
-                      std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator);
+        Result insertTrack(QueueInsertionPosition position, FileHash hash);
+        Result insertTrack(QueueInsertionPosition position, uint trackId);
+
         Result insertAtIndex(qint32 index, SpecialQueueItemType itemType,
                              std::function<void (uint)> queueIdNotifier);
-        Result insertAtIndex(qint32 index,
-                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
-                       std::function<void (uint)> queueIdNotifier);
+        Result insertAtIndex(qint32 index, uint trackId,
+                             std::function<void (uint)> queueIdNotifier);
+        Result insertAtIndex(qint32 index, FileHash hash,
+                             std::function<void (uint)> queueIdNotifier);
+
+        Result duplicateEntryWithId(uint queueId,
+                                    std::function<void (uint)> queueIdNotifier);
 
         QList<QSharedPointer<RecentHistoryEntry>> recentHistory(int limit);
 
@@ -145,6 +149,12 @@ namespace PMP::Server
         void checkFrontOfQueue();
 
     private:
+        int toIndex(QueueInsertionPosition position);
+        Result insertAtIndex(qint32 index,
+                    std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator);
+        Result insertAtIndex(qint32 index,
+                    std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
+                    std::function<void (uint)> queueIdNotifier);
         QueueEntryIdsAndHash toQueueEntryIdsAndHash(QSharedPointer<QueueEntry>) const;
         void resetFirstTrack();
         void setFirstTrackIndexAndId(int index, uint queueId);

--- a/src/server/preloader.cpp
+++ b/src/server/preloader.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -63,8 +63,8 @@ namespace PMP::Server
     class Preloader::PreloadTrack
     {
     public:
-        PreloadTrack(FileHash hash, QString filename)
-         : _status(Initial), _hash(hash), _filename(filename)
+        PreloadTrack(uint trackId, QString filename)
+         : _status(Initial), _trackId(trackId), _filename(filename)
         {
             //
         }
@@ -76,9 +76,9 @@ namespace PMP::Server
 
         enum Status { Initial = 0, Processing, Preloaded, Failed, CleanedUp };
 
-        Status status() const;
-        FileHash const& hash() const;
-        QString originalFilename() const;
+        Status status() const { return _status; }
+        uint trackId() const { return _trackId; }
+        QString originalFilename() const { return _filename; }
 
         void setToLoading();
         void setToFailed();
@@ -89,25 +89,10 @@ namespace PMP::Server
 
     private:
         Status _status;
-        FileHash _hash;
+        uint _trackId;
         QString _filename;
         QString _cacheFile;
     };
-
-    Preloader::PreloadTrack::Status Preloader::PreloadTrack::status() const
-    {
-        return _status;
-    }
-
-    FileHash const& Preloader::PreloadTrack::hash() const
-    {
-        return _hash;
-    }
-
-    QString Preloader::PreloadTrack::originalFilename() const
-    {
-        return _filename;
-    }
 
     void Preloader::PreloadTrack::setToLoading()
     {
@@ -320,7 +305,7 @@ namespace PMP::Server
         if (!entry->isTrack())
             return;
 
-        FileHash hash = entry->hash().value();
+        auto trackId = entry->trackId().value();
         Nullable<QString> filename = entry->filename();
 
         auto id = entry->queueID();
@@ -342,17 +327,17 @@ namespace PMP::Server
 
         qDebug() << "putting queue ID" << id << "on the list for preloading";
 
-        track = new PreloadTrack(hash, filename.valueOr({}));
+        track = new PreloadTrack(trackId, filename.valueOr({}));
 
         _tracksByQueueID.insert(id, track);
         _tracksToPreload.append(id);
     }
 
-    Future<QString, FailureType> Preloader::preloadAsync(uint queueId, FileHash hash,
+    Future<QString, FailureType> Preloader::preloadAsync(uint queueId, uint trackId,
                                                          QString originalFilename)
     {
         if (!originalFilename.isEmpty()
-                && _resolver->pathStillValid(hash, originalFilename))
+                && _resolver->pathStillValid(trackId, originalFilename))
         {
             return Concurrent::runOnThreadPool<QString, FailureType>(
                 globalThreadPool,
@@ -364,10 +349,10 @@ namespace PMP::Server
         }
 
         qDebug() << "Preloader: don't have a filename yet for queue ID" << queueId
-                 << "which has hash" << hash;
+                 << "which has track ID" << trackId;
 
         return
-            _resolver->findPathForHashAsync(hash)
+            _resolver->findPathForTrackAsync(trackId)
                 .thenOnThreadPool<QString, FailureType>(
                     globalThreadPool,
                     [queueId](FailureOr<QString> outcome) -> FailureOr<QString>
@@ -480,7 +465,9 @@ namespace PMP::Server
 
             track->setToLoading();
 
-            auto future = preloadAsync(queueId, track->hash(), track->originalFilename());
+            auto future = preloadAsync(queueId,
+                                       track->trackId(),
+                                       track->originalFilename());
             _jobsRunning++;
 
             future.handleOnEventLoop(

--- a/src/server/preloader.h
+++ b/src/server/preloader.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2016-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,11 +17,10 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_PRELOADER_H
-#define PMP_PRELOADER_H
+#ifndef PMP_SERVER_PRELOADER_H
+#define PMP_SERVER_PRELOADER_H
 
 #include "common/abstracthandle.h"
-#include "common/filehash.h"
 #include "common/future.h"
 #include "common/qobjectresourcekeeper.h"
 
@@ -96,7 +95,7 @@ namespace PMP::Server
 
         void checkToPreloadTrack(QSharedPointer<QueueEntry> entry);
 
-        Future<QString, FailureType> preloadAsync(uint queueId, FileHash hash,
+        Future<QString, FailureType> preloadAsync(uint queueId, uint trackId,
                                                   QString originalFilename);
         static ResultOrError<QString, FailureType> runPreload(uint queueId,
                                                               QString originalFilename);

--- a/src/server/queueentry.cpp
+++ b/src/server/queueentry.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -26,10 +26,10 @@
 
 namespace PMP::Server
 {
-    QueueEntry::QueueEntry(uint queueId, FileHash hash)
+    QueueEntry::QueueEntry(uint queueId, uint trackId)
      : _queueID(queueId),
        _kind(QueueEntryKind::Track),
-       _hash(hash),
+       _trackId(trackId),
        _haveFilename(false),
        _fetchedTagData(false),
        _fileFinderBackoff(0),
@@ -41,7 +41,7 @@ namespace PMP::Server
     QueueEntry::QueueEntry(uint queueId, QSharedPointer<QueueEntry const> existing)
      : _queueID(queueId),
        _kind(existing->_kind),
-       _hash(existing->_hash),
+       _trackId(existing->_trackId),
        _audioInfo(existing->_audioInfo),
        _filename(existing->_filename),
        _haveFilename(existing->_haveFilename),
@@ -56,7 +56,7 @@ namespace PMP::Server
     QueueEntry::QueueEntry(uint queueId, QueueEntryKind kind)
      : _queueID(queueId),
        _kind(kind),
-       _hash{},
+       _trackId(0),
        _haveFilename(false),
        _fetchedTagData(false),
        _fileFinderBackoff(0),
@@ -75,9 +75,9 @@ namespace PMP::Server
         return QSharedPointer<QueueEntry>::create(queueId, QueueEntryKind::Barrier);
     }
 
-    QSharedPointer<QueueEntry> QueueEntry::createFromHash(uint queueId, FileHash hash)
+    QSharedPointer<QueueEntry> QueueEntry::createFromTrackId(uint queueId, uint trackId)
     {
-        return QSharedPointer<QueueEntry>::create(queueId, hash);
+        return QSharedPointer<QueueEntry>::create(queueId, trackId);
     }
 
     QSharedPointer<QueueEntry> QueueEntry::createCopyOf(uint queueId,
@@ -89,14 +89,6 @@ namespace PMP::Server
     QueueEntry::~QueueEntry()
     {
         //
-    }
-
-    Nullable<FileHash> QueueEntry::hash() const
-    {
-        if (_hash.isNull())
-            return null;
-
-        return _hash;
     }
 
     void QueueEntry::setFilename(QString const& filename)
@@ -121,11 +113,11 @@ namespace PMP::Server
 
     void QueueEntry::checkAudioData(Resolver& resolver)
     {
-        if (_hash.isNull()) return;
+        if (_trackId == 0) return;
 
         if (!_audioInfo.isComplete())
         {
-            auto audioDataFound = resolver.findAudioData(_hash);
+            auto audioDataFound = resolver.findAudioData(_trackId);
 
             if (audioDataFound.hasValue())
                 _audioInfo = audioDataFound.value();
@@ -134,13 +126,13 @@ namespace PMP::Server
 
     void QueueEntry::checkTrackData(Resolver& resolver)
     {
-        if (_hash.isNull()) return;
+        if (_trackId == 0) return;
 
         checkAudioData(resolver);
 
         if (_fetchedTagData) return;
 
-        auto tagDataFound = resolver.findTagData(_hash);
+        auto tagDataFound = resolver.findTagData(_trackId);
         if (tagDataFound.hasValue())
         {
             _tagData = tagDataFound.value();

--- a/src/server/queueentry.h
+++ b/src/server/queueentry.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -21,9 +21,10 @@
 #define PMP_QUEUEENTRY_H
 
 #include "common/audiodata.h"
-#include "common/filehash.h"
 #include "common/nullable.h"
 #include "common/tagdata.h"
+
+#include "queueentrykind.h"
 
 #include <QDateTime>
 #include <QSharedPointer>
@@ -35,19 +36,12 @@ namespace PMP::Server
     class PlayerQueue;
     class Resolver;
 
-    enum class QueueEntryKind
-    {
-        Track = 0,
-        Break,
-        Barrier,
-    };
-
     class QueueEntry
     {
     public:
         static QSharedPointer<QueueEntry> createBreak(uint queueId);
         static QSharedPointer<QueueEntry> createBarrier(uint queueId);
-        static QSharedPointer<QueueEntry> createFromHash(uint queueId, FileHash hash);
+        static QSharedPointer<QueueEntry> createFromTrackId(uint queueId, uint trackId);
         static QSharedPointer<QueueEntry> createCopyOf(uint queueId,
                                                QSharedPointer<QueueEntry const> existing);
 
@@ -57,7 +51,10 @@ namespace PMP::Server
         QueueEntryKind kind() const { return _kind; }
         bool isTrack() const { return _kind == QueueEntryKind::Track; }
 
-        Nullable<FileHash> hash() const;
+        Nullable<uint> trackId() const
+        {
+            if (_trackId > 0) return _trackId; else return null;
+        }
 
         void setFilename(QString const& filename);
         Nullable<QString> filename() const;
@@ -83,7 +80,7 @@ namespace PMP::Server
         void setEndedNow();
 
     private:
-        QueueEntry(uint queueId, FileHash hash);
+        QueueEntry(uint queueId, uint trackId);
         QueueEntry(uint queueId, QSharedPointer<QueueEntry const> existing);
         QueueEntry(uint queueId, QueueEntryKind kind);
 
@@ -91,7 +88,7 @@ namespace PMP::Server
 
         uint const _queueID;
         QueueEntryKind _kind;
-        FileHash _hash;
+        uint _trackId;
         //bool _fetchedAudioInfo;
         AudioData _audioInfo;
         QString _filename;
@@ -112,12 +109,12 @@ namespace PMP::Server
             return QueueEntry::createBreak;
         }
 
-        static std::function<QSharedPointer<QueueEntry> (uint)> hash(FileHash hash)
+        static std::function<QSharedPointer<QueueEntry> (uint)> track(uint trackId)
         {
             return
-                [hash](uint queueId)
+                [trackId](uint queueId)
                 {
-                    return QueueEntry::createFromHash(queueId, hash);
+                    return QueueEntry::createFromTrackId(queueId, trackId);
                 };
         }
 

--- a/src/server/queueentryidsandhash.h
+++ b/src/server/queueentryidsandhash.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023-2025, Kevin André <hyperquantum@gmail.com>
+    Copyright (C) 2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,24 +17,21 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_SERVER_TRACKINFOPROVIDER_H
-#define PMP_SERVER_TRACKINFOPROVIDER_H
+#ifndef PMP_SERVER_QUEUEENTRYIDSANDHASH_H
+#define PMP_SERVER_QUEUEENTRYIDSANDHASH_H
 
-#include "common/future.h"
+#include "common/nullable.h"
 
-#include "collectiontrackinfo.h"
+#include "filehashwithid.h"
+#include "queueentrykind.h"
 
 namespace PMP::Server
 {
-    class TrackInfoProvider
+    struct QueueEntryIdsAndHash
     {
-    protected:
-        TrackInfoProvider() {}
-    public:
-        virtual ~TrackInfoProvider() {}
-
-        virtual Future<CollectionTrackInfo, FailureType> getTrackInfoAsync(
-                                                                        uint trackId) = 0;
+        uint queueId;
+        QueueEntryKind kind;
+        Nullable<FileHashWithId> hashAndId;
     };
 }
 #endif

--- a/src/server/queueentrykind.h
+++ b/src/server/queueentrykind.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023-2025, Kevin André <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,24 +17,16 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_SERVER_TRACKINFOPROVIDER_H
-#define PMP_SERVER_TRACKINFOPROVIDER_H
-
-#include "common/future.h"
-
-#include "collectiontrackinfo.h"
+#ifndef PMP_SERVER_QUEUEENTRYKIND_H
+#define PMP_SERVER_QUEUEENTRYKIND_H
 
 namespace PMP::Server
 {
-    class TrackInfoProvider
+    enum class QueueEntryKind
     {
-    protected:
-        TrackInfoProvider() {}
-    public:
-        virtual ~TrackInfoProvider() {}
-
-        virtual Future<CollectionTrackInfo, FailureType> getTrackInfoAsync(
-                                                                        uint trackId) = 0;
+        Track = 0,
+        Break,
+        Barrier,
     };
 }
 #endif

--- a/src/server/queueinsertionposition.h
+++ b/src/server/queueinsertionposition.h
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2025, Kevin André <hyperquantum@gmail.com>
+
+    This file is part of PMP (Party Music Player).
+
+    PMP is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License as published by the Free Software
+    Foundation, either version 3 of the License, or (at your option) any later
+    version.
+
+    PMP is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along
+    with PMP.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef PMP_SERVER_QUEUEINSERTIONPOSITION_H
+#define PMP_SERVER_QUEUEINSERTIONPOSITION_H
+
+#include <QDebug>
+
+namespace PMP::Server
+{
+    enum class QueueInsertionPosition
+    {
+        Front, End
+    };
+
+    inline QDebug operator<<(QDebug debug, QueueInsertionPosition position)
+    {
+        switch (position)
+        {
+        case QueueInsertionPosition::Front:
+            return debug << "FRONT";
+        case QueueInsertionPosition::End:
+            return debug << "END";
+        }
+
+        return debug << (int)position;
+    }
+}
+#endif

--- a/src/server/recenthistoryentry.h
+++ b/src/server/recenthistoryentry.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,10 +17,8 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_RECENTHISTORYENTRY_H
-#define PMP_RECENTHISTORYENTRY_H
-
-#include "common/filehash.h"
+#ifndef PMP_SERVER_RECENTHISTORYENTRY_H
+#define PMP_SERVER_RECENTHISTORYENTRY_H
 
 #include <QDateTime>
 #include <QtGlobal>
@@ -30,17 +28,18 @@ namespace PMP::Server
     class RecentHistoryEntry
     {
     public:
-        RecentHistoryEntry(uint queueId, FileHash hash, uint user,
+        RecentHistoryEntry(uint queueId, uint trackId, uint user,
                            QDateTime started, QDateTime ended,
                            bool hadError, bool hadSeek, int permillage)
-         : _queueId(queueId), _hash(hash), _user(user), _started(started), _ended(ended),
-           _permillage(permillage), _error(hadError), _seek(hadSeek)
+         : _queueId(queueId), _trackId(trackId), _user(user),
+            _started(started), _ended(ended), _permillage(permillage),
+            _error(hadError), _seek(hadSeek)
         {
             //
         }
 
         uint queueID() const { return _queueId; }
-        FileHash hash() const { return _hash; }
+        uint trackId() const { return _trackId; }
         uint user() const { return _user; }
         QDateTime started() const { return _started; }
         QDateTime ended() const { return _ended; }
@@ -52,7 +51,7 @@ namespace PMP::Server
 
     private:
         uint _queueId;
-        FileHash _hash;
+        uint _trackId;
         uint _user;
         QDateTime _started;
         QDateTime _ended;

--- a/src/server/resolver.cpp
+++ b/src/server/resolver.cpp
@@ -243,7 +243,7 @@ namespace PMP::Server
 
         if (lengthChanged || quickTagsChanged)
         {
-            Q_EMIT _parent->hashTagInfoChanged(_hash, _quickTitle, _quickArtist,
+            Q_EMIT _parent->hashTagInfoChanged(_hashId, _hash, _quickTitle, _quickArtist,
                                                _quickAlbum, _quickAlbumArtist,
                                                _audio.trackLengthMilliseconds());
         }
@@ -1026,7 +1026,7 @@ namespace PMP::Server
                 lengthInMilliseconds = 0;
             }
 
-            CollectionTrackInfo info(hash, knowledge->isAvailable(),
+            CollectionTrackInfo info(knowledge->id(), hash, knowledge->isAvailable(),
                                      knowledge->quickTitle(), knowledge->quickArtist(),
                                      knowledge->quickAlbum(),
                                      knowledge->quickAlbumArtist(),
@@ -1051,7 +1051,7 @@ namespace PMP::Server
             lengthInMilliseconds = 0;
         }
 
-        CollectionTrackInfo info(knowledge->hash(), knowledge->isAvailable(),
+        CollectionTrackInfo info(hashId, knowledge->hash(), knowledge->isAvailable(),
                                  knowledge->quickTitle(), knowledge->quickArtist(),
                                  knowledge->quickAlbum(), knowledge->quickAlbumArtist(),
                                  qint32(lengthInMilliseconds));

--- a/src/server/resolver.cpp
+++ b/src/server/resolver.cpp
@@ -661,58 +661,17 @@ namespace PMP::Server
         }
     }
 
-    Future<QString, FailureType> Resolver::findPathForHashAsync(FileHash hash)
-    {
-        if (hash.isNull())
-        {
-            qWarning() << "Resolver: cannot find path for null hash";
-            return FutureError(failure);
-        }
-
-        {
-            QMutexLocker lock(&_lock);
-
-            auto it = _hashToKnowledge.find(hash);
-            if (it != _hashToKnowledge.end())
-            {
-                auto path = it.value()->getFile();
-                if (!path.isEmpty())
-                {
-                    return FutureResult(path);
-                }
-            }
-        }
-
-        auto idFuture = _hashIdRegistrar->getOrCreateId(hash);
-
-        // TODO : check if we have it in the locations cache
-
-        auto pathFuture =
-            idFuture.thenOnAnyThreadIndirect<QString, FailureType>(
-                [this, hash](FailureOr<uint> outcome) -> Future<QString, FailureType>
-                {
-                    if (outcome.failed())
-                        return FutureError(failure);
-
-                    auto id = outcome.result();
-                    return _fileFinder->findHashAsync(id, hash);
-                }
-            );
-
-        return pathFuture;
-    }
-
-    Future<QString, FailureType> Resolver::findPathForHashAsync(uint hashId)
+    Future<QString, FailureType> Resolver::findPathForTrackAsync(uint trackId)
     {
         FileHash hash;
 
         {
             QMutexLocker lock(&_lock);
 
-            auto it = _idToKnowledge.find(hashId);
+            auto it = _idToKnowledge.find(trackId);
             if (it == _idToKnowledge.end())
             {
-                qWarning() << "Resolver: hash ID" << hashId << "is unknown";
+                qWarning() << "Resolver: track ID" << trackId << "is unknown";
                 return FutureError(failure);
             }
 
@@ -727,7 +686,7 @@ namespace PMP::Server
 
         // TODO : check if we have it in the locations cache
 
-        return _fileFinder->findHashAsync(hashId, hash);
+        return _fileFinder->findHashAsync(trackId, hash);
     }
 
     Future<SuccessType, FailureType> Resolver::waitUntilAnyFileAnalyzed(uint hashId)
@@ -933,7 +892,7 @@ namespace PMP::Server
         return knowledge && knowledge->isAvailable();
     }
 
-    bool Resolver::pathStillValid(const FileHash& hash, QString path)
+    bool Resolver::pathStillValid(uint trackId, QString path)
     {
         QMutexLocker lock(&_lock);
 
@@ -941,7 +900,7 @@ namespace PMP::Server
         if (!file) return false;
 
         auto knowledge = file->_parent;
-        if (knowledge->hash() != hash) return false;
+        if (knowledge->id() != trackId) return false;
 
         return knowledge->isStillValid(file);
     }
@@ -974,6 +933,16 @@ namespace PMP::Server
         (void)knowledge->isStillValid(file);
     }
 
+    Nullable<AudioData> Resolver::findAudioData(uint trackId)
+    {
+        QMutexLocker lock(&_lock);
+
+        auto knowledge = _idToKnowledge.value(trackId, nullptr);
+        if (knowledge) return knowledge->audio();
+
+        return null;
+    }
+
     Nullable<AudioData> Resolver::findAudioData(const FileHash& hash)
     {
         QMutexLocker lock(&_lock);
@@ -984,11 +953,11 @@ namespace PMP::Server
         return null;
     }
 
-    Nullable<TagData> Resolver::findTagData(const FileHash& hash)
+    Nullable<TagData> Resolver::findTagData(uint trackId)
     {
         QMutexLocker lock(&_lock);
 
-        auto knowledge = _hashToKnowledge.value(hash, nullptr);
+        auto knowledge = _idToKnowledge.value(trackId, nullptr);
 
         if (knowledge)
         {

--- a/src/server/resolver.h
+++ b/src/server/resolver.h
@@ -64,16 +64,16 @@ namespace PMP::Server
         bool isFullIndexationRunning();
         bool isQuickScanForNewFilesRunning();
 
-        Future<QString, FailureType> findPathForHashAsync(FileHash hash);
-        Future<QString, FailureType> findPathForHashAsync(uint hashId);
+        Future<QString, FailureType> findPathForTrackAsync(uint trackId);
         Future<SuccessType, FailureType> waitUntilAnyFileAnalyzed(uint hashId);
 
         bool haveFileForHash(const FileHash& hash);
-        bool pathStillValid(const FileHash& hash, QString path);
+        bool pathStillValid(uint trackId, QString path);
         Nullable<FileHash> getHashForFilePath(QString path);
 
+        Nullable<AudioData> findAudioData(uint trackId);
         Nullable<AudioData> findAudioData(const FileHash& hash);
-        Nullable<TagData> findTagData(const FileHash& hash);
+        Nullable<TagData> findTagData(uint trackId);
 
         QVector<FileHash> getAllHashes();
         QVector<CollectionTrackInfo> getHashesTrackInfo(QVector<FileHash> hashes);

--- a/src/server/resolver.h
+++ b/src/server/resolver.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -96,7 +96,8 @@ namespace PMP::Server
 
         void hashBecameAvailable(PMP::FileHash hash);
         void hashBecameUnavailable(PMP::FileHash hash);
-        void hashTagInfoChanged(PMP::FileHash hash, QString title, QString artist,
+        void hashTagInfoChanged(uint hashId, PMP::FileHash hash,
+                                QString title, QString artist,
                                 QString album, QString albumArtist,
                                 qint32 lengthInMilliseconds);
 

--- a/src/server/result.h
+++ b/src/server/result.h
@@ -37,6 +37,8 @@ namespace PMP::Server
 
         HashIsNull,
         HashIsUnknown,
+        TrackIdIsZero,
+        TrackIdIsUnknown,
 
         QueueEntryIdNotFound,
         QueueIndexOutOfRange,
@@ -122,6 +124,9 @@ namespace PMP::Server
 
         static Error hashIsNull() { return Error(ResultCode::HashIsNull); }
         static Error hashIsUnknown() { return Error(ResultCode::HashIsUnknown); }
+
+        static Error trackIdIsZero() { return Error(ResultCode::TrackIdIsZero); }
+        static Error trackIdIsUnknown() { return Error(ResultCode::TrackIdIsUnknown); }
 
         static Error queueEntryIdNotFound(uint id)
         {

--- a/src/server/result.h
+++ b/src/server/result.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2021-2023, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2021-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -19,6 +19,8 @@
 
 #ifndef PMP_SERVER_RESULT_H
 #define PMP_SERVER_RESULT_H
+
+#include "common/future.h"
 
 #include <QtGlobal>
 
@@ -111,72 +113,83 @@ namespace PMP::Server
     class Error : public Result
     {
     public:
-        static Result notLoggedIn() { return Error(ResultCode::NotLoggedIn); }
+        static Error notLoggedIn() { return Error(ResultCode::NotLoggedIn); }
 
-        static Result operationAlreadyRunning()
+        static Error operationAlreadyRunning()
         {
             return Error(ResultCode::OperationAlreadyRunning);
         }
 
-        static Result hashIsNull() { return Error(ResultCode::HashIsNull); }
-        static Result hashIsUnknown() { return Error(ResultCode::HashIsUnknown); }
+        static Error hashIsNull() { return Error(ResultCode::HashIsNull); }
+        static Error hashIsUnknown() { return Error(ResultCode::HashIsUnknown); }
 
-        static Result queueEntryIdNotFound(uint id)
+        static Error queueEntryIdNotFound(uint id)
         {
             return Error(ResultCode::QueueEntryIdNotFound, id);
         }
 
-        static Result queueIndexOutOfRange()
+        static Error queueIndexOutOfRange()
         {
             return Error(ResultCode::QueueIndexOutOfRange);
         }
 
-        static Result queueMaxSizeExceeded()
+        static Error queueMaxSizeExceeded()
         {
             return Error(ResultCode::QueueMaxSizeExceeded);
         }
 
-        static Result queueItemTypeInvalid()
+        static Error queueItemTypeInvalid()
         {
             return Error(ResultCode::QueueItemTypeInvalid);
         }
 
-        static Result delayOutOfRange() { return Error(ResultCode::DelayOutOfRange); }
+        static Error delayOutOfRange() { return Error(ResultCode::DelayOutOfRange); }
 
-        static Result userIdNotFound() { return Error(ResultCode::UserIdNotFound); }
+        static Error userIdNotFound() { return Error(ResultCode::UserIdNotFound); }
 
-        static Result scrobblingSystemDisabled()
+        static Error scrobblingSystemDisabled()
         {
             return Error(ResultCode::ScrobblingSystemDisabled);
         }
 
-        static Result scrobblingProviderInvalid()
+        static Error scrobblingProviderInvalid()
         {
             return Error(ResultCode::ScrobblingProviderInvalid);
         }
 
-        static Result scrobblingProviderNotEnabled()
+        static Error scrobblingProviderNotEnabled()
         {
             return Error(ResultCode::ScrobblingProviderNotEnabled);
         }
 
-        static Result scrobblingAuthenticationFailed()
+        static Error scrobblingAuthenticationFailed()
         {
             return Error(ResultCode::ScrobblingAuthenticationFailed);
         }
 
-        static Result unspecifiedScrobblingBackendError()
+        static Error unspecifiedScrobblingBackendError()
         {
             return Error(ResultCode::UnspecifiedScrobblingBackendError);
         }
 
-        static Result databaseUnvailable()
+        static Error databaseUnvailable()
         {
             return Error(ResultCode::DatabaseUnavailable);
         }
 
-        static Result notImplemented() { return Error(ResultCode::NotImplementedError); }
-        static Result internalError() { return Error(ResultCode::InternalError); }
+        static Error notImplemented() { return Error(ResultCode::NotImplementedError); }
+        static Error internalError() { return Error(ResultCode::InternalError); }
+
+        operator SimpleFuture<Result>() const
+        {
+            return FutureResult<Result>(*this);
+        }
+
+        template <class TResult>
+        operator Future<TResult, Error>() const
+        {
+            return FutureError(*this);
+        }
 
     private:
         Error(ResultCode code) : Result(code) {}

--- a/src/server/scrobblinghost.cpp
+++ b/src/server/scrobblinghost.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2019-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2019-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -54,19 +54,19 @@ namespace PMP::Server
                                                             QString password)
     {
         if (!_hostEnabled)
-            return FutureResult(Error::scrobblingSystemDisabled());
+            return Error::scrobblingSystemDisabled();
 
         auto& data = _scrobblersData[userId][provider];
 
         if (data.enabled == false)
         {
-            return FutureResult(Error::scrobblingProviderNotEnabled());
+            return Error::scrobblingProviderNotEnabled();
         }
 
         if (data.scrobbler == nullptr)
         {
             qWarning() << "ScrobblingHost: authenticate: scrobbler not created yet??";
-            return FutureResult(Error::internalError());
+            return Error::internalError();
         }
 
         return data.scrobbler->authenticateWithCredentials(user, password);

--- a/src/server/server-main.cpp
+++ b/src/server/server-main.cpp
@@ -246,10 +246,10 @@ static int runServer(QCoreApplication& app, bool doIndexation)
     Resolver resolver(&hashIdRegistrar, &hashRelations, &historyStatistics);
 
     Users users;
-    Player player(nullptr, &resolver, serverSettings.defaultVolume());
+    Player player(nullptr, &hashIdRegistrar, &resolver, serverSettings.defaultVolume());
     DelayedStart delayedStart(&player);
     PlayerQueue& queue = player.queue();
-    History history(&player, &hashIdRegistrar, &historyStatistics);
+    History history(&player, &historyStatistics);
     UserHashStatsCacheFixer hashStatsCacheFixer(&historyStatistics);
 
     CollectionMonitor collectionMonitor;

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -227,32 +227,32 @@ namespace PMP::Server
         _player->setUserPlayingFor(0);
     }
 
-    Future<HistoryFragment, Result> ServerInterface::getPersonalTrackHistory(
+    Future<HistoryFragment, Error> ServerInterface::getPersonalTrackHistory(
         FileHash hash, quint32 userId, uint startId, int limit)
     {
         if (!isLoggedIn())
-            return FutureError(Error::notLoggedIn());
+            return Error::notLoggedIn();
 
         if (hash.isNull())
-            return FutureError(Error::hashIsNull());
+            return Error::hashIsNull();
 
         auto maybeHashId = _hashIdRegistrar->getIdForHash(hash);
         if (maybeHashId == null)
-            return FutureError(Error::hashIsUnknown());
+            return Error::hashIsUnknown();
 
         auto hashIds =
             _hashRelations->getEquivalencyGroup(maybeHashId.value());
 
         if (userId != 0 && !_users->checkUserIdExists(userId))
-            return FutureError(Error::userIdNotFound());
+            return Error::userIdNotFound();
 
         limit = qBound(0, limit, 50);
 
         auto future =
-            Concurrent::runOnThreadPool<HistoryFragment, Result>(
+            Concurrent::runOnThreadPool<HistoryFragment, Error>(
                 globalThreadPool,
                 [hashIds, hash, userId, startId, limit]()
-                    -> ResultOrError<HistoryFragment, Result>
+                    -> ResultOrError<HistoryFragment, Error>
                 {
                     auto db = Database::getDatabaseForCurrentThread();
                     if (!db)
@@ -321,10 +321,10 @@ namespace PMP::Server
                                                             QString password)
     {
         if (!isLoggedIn())
-            return FutureResult(Error::notLoggedIn());
+            return Error::notLoggedIn();
 
         if (provider == ScrobblingProvider::Unknown)
-            return FutureResult(Error::scrobblingProviderInvalid());
+            return Error::scrobblingProviderInvalid();
 
         return _scrobbling->authenticateForProvider(_userLoggedIn, provider, user,
                                                     password);
@@ -405,7 +405,7 @@ namespace PMP::Server
         return overview;
     }
 
-    Future<QVector<QString>, Result>
+    Future<QVector<QString>, Error>
         ServerInterface::getPossibleFilenamesForQueueEntry(uint id)
     {
         if (id <= 0) /* invalid queue ID */
@@ -422,9 +422,9 @@ namespace PMP::Server
         uint hashId = _player->resolver().getID(hash);
 
         auto future =
-            Concurrent::runOnThreadPool<QVector<QString>, Result>(
+            Concurrent::runOnThreadPool<QVector<QString>, Error>(
                 globalThreadPool,
-                [hashId]() -> ResultOrError<QVector<QString>, Result>
+                [hashId]() -> ResultOrError<QVector<QString>, Error>
                 {
                     auto db = Database::getDatabaseForCurrentThread();
                     if (!db)
@@ -671,16 +671,16 @@ namespace PMP::Server
             Q_EMIT hashUserDataChangedOrAvailable(userId, hashStatsAlreadyAvailable);
     }
 
-    Future<CollectionTrackInfo, Result> ServerInterface::getHashInfo(FileHash hash)
+    Future<CollectionTrackInfo, Error> ServerInterface::getHashInfo(FileHash hash)
     {
         /* note: client does not need to be logged in for this */
 
         if (hash.isNull())
-            return FutureError(Error::hashIsNull());
+            return Error::hashIsNull();
 
         auto maybeHashId = _hashIdRegistrar->getIdForHash(hash);
         if (maybeHashId == null)
-            return FutureError(Error::hashIsUnknown());
+            return Error::hashIsUnknown();
 
         auto hashInfo = _player->resolver().getHashTrackInfo(maybeHashId.value());
 

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -449,32 +449,6 @@ namespace PMP::Server
         return future;
     }
 
-    Result ServerInterface::insertTrackAtEnd(FileHash hash)
-    {
-        if (!isLoggedIn())
-            return Error::notLoggedIn();
-
-        if (_hashIdRegistrar->isRegistered(hash) == false)
-            return Error::hashIsUnknown();
-
-        auto& queue = _player->queue();
-
-        return queue.enqueue(hash);
-    }
-
-    Result ServerInterface::insertTrackAtFront(FileHash hash)
-    {
-        if (!isLoggedIn())
-            return Error::notLoggedIn();
-
-        if (_hashIdRegistrar->isRegistered(hash) == false)
-            return Error::hashIsUnknown();
-
-        auto& queue = _player->queue();
-
-        return queue.insertAtFront(hash);
-    }
-
     Result ServerInterface::insertBreakAtFrontIfNotExists()
     {
         if (!isLoggedIn())
@@ -488,18 +462,63 @@ namespace PMP::Server
         return queue.insertBreakAtFront();
     }
 
+    Result ServerInterface::insertTrack(QueueInsertionPosition position, quint64 trackId)
+    {
+        if (!isLoggedIn())
+            return Error::notLoggedIn();
+
+        auto possiblyTruncatedTrackId = static_cast<uint>(trackId);
+        if (possiblyTruncatedTrackId != trackId)
+            return Error::trackIdIsUnknown();
+
+        /* other checks of the track ID are done by Queue */
+
+        auto& queue = _player->queue();
+
+        return queue.insertTrack(position, possiblyTruncatedTrackId);
+    }
+
+    Result ServerInterface::insertTrack(QueueInsertionPosition position, FileHash hash)
+    {
+        if (!isLoggedIn())
+            return Error::notLoggedIn();
+
+        /* other checks of the track hash are done by Queue */
+
+        auto& queue = _player->queue();
+
+        return queue.insertTrack(position, hash);
+    }
+
+    Result ServerInterface::insertTrack(quint64 trackId, int index,
+                                        quint32 clientReference)
+    {
+        if (!isLoggedIn())
+            return Error::notLoggedIn();
+
+        auto possiblyTruncatedTrackId = static_cast<uint>(trackId);
+        if (possiblyTruncatedTrackId != trackId)
+            return Error::trackIdIsUnknown();
+
+        /* other checks of the track hash are done by Queue */
+
+        auto& queue = _player->queue();
+
+        return queue.insertAtIndex(index, trackId,
+                                   createQueueInsertionIdNotifier(clientReference));
+    }
+
     Result ServerInterface::insertTrack(FileHash hash, int index, quint32 clientReference)
     {
         if (!isLoggedIn())
             return Error::notLoggedIn();
 
-        auto trackId = _hashIdRegistrar->getIdForHash(hash);
-        if (trackId == null)
-            return Error::hashIsUnknown();
+        /* other checks of the track hash are done by Queue */
 
-        auto entryCreator = QueueEntryCreators::track(trackId.value());
+        auto& queue = _player->queue();
 
-        return insertAtIndex(index, entryCreator, clientReference);
+        return queue.insertAtIndex(index, hash,
+                                   createQueueInsertionIdNotifier(clientReference));
     }
 
     Result ServerInterface::insertSpecialQueueItem(SpecialQueueItemType itemType,
@@ -525,30 +544,8 @@ namespace PMP::Server
 
         auto& queue = _player->queue();
 
-        auto index = queue.findIndex(id);
-        if (index < 0)
-            return Error::queueEntryIdNotFound(id);
-
-        auto existing = queue.entryAtIndex(index);
-        if (!existing || existing->queueID() != id)
-        {
-            qWarning() << "queue inconsistency for QID" << id;
-            return Error::internalError();
-        }
-
-        auto entryCreator = QueueEntryCreators::copyOf(existing);
-
-        return insertAtIndex(index + 1, entryCreator, clientReference);
-    }
-
-    Result ServerInterface::insertAtIndex(qint32 index,
-                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
-                       quint32 clientReference)
-    {
-        auto& queue = _player->queue();
-
-        return queue.insertAtIndex(index, queueEntryCreator,
-                                   createQueueInsertionIdNotifier(clientReference));
+        return queue.duplicateEntryWithId(id,
+                                        createQueueInsertionIdNotifier(clientReference));
     }
 
     void ServerInterface::moveQueueEntry(uint id, int upDownOffset)

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -405,6 +405,12 @@ namespace PMP::Server
         return overview;
     }
 
+    QList<ResultOrError<QueueEntryIdsAndHash, Error>>
+        ServerInterface::getTrackIdAndHashForQueueIds(QList<uint> ids)
+    {
+        return _player->queue().getHashAndTrackIdForQueueIds(ids);
+    }
+
     Future<QVector<QString>, Error>
         ServerInterface::getPossibleFilenamesForQueueEntry(uint id)
     {
@@ -418,19 +424,18 @@ namespace PMP::Server
         if (!entry->isTrack())
             return FutureError(Error::queueItemTypeInvalid());
 
-        auto hash = entry->hash().value();
-        uint hashId = _player->resolver().getID(hash);
+        auto trackId = entry->trackId().value();
 
         auto future =
             Concurrent::runOnThreadPool<QVector<QString>, Error>(
                 globalThreadPool,
-                [hashId]() -> ResultOrError<QVector<QString>, Error>
+                [trackId]() -> ResultOrError<QVector<QString>, Error>
                 {
                     auto db = Database::getDatabaseForCurrentThread();
                     if (!db)
                         return Error::databaseUnvailable();
 
-                    auto filenamesOrFailure = db->getFilenames(hashId);
+                    auto filenamesOrFailure = db->getFilenames(trackId);
 
                     if (filenamesOrFailure.failed())
                         return Error::internalError();
@@ -486,10 +491,11 @@ namespace PMP::Server
         if (!isLoggedIn())
             return Error::notLoggedIn();
 
-        if (_hashIdRegistrar->isRegistered(hash) == false)
+        auto trackId = _hashIdRegistrar->getIdForHash(hash);
+        if (trackId == null)
             return Error::hashIsUnknown();
 
-        auto entryCreator = QueueEntryCreators::hash(hash);
+        auto entryCreator = QueueEntryCreators::track(trackId.value());
 
         return insertAtIndex(index, entryCreator, clientReference);
     }
@@ -685,6 +691,11 @@ namespace PMP::Server
         auto hashInfo = _player->resolver().getHashTrackInfo(maybeHashId.value());
 
         return FutureResult(hashInfo);
+    }
+
+    Nullable<FileHash> ServerInterface::getHashForTrackId(uint trackId) const
+    {
+        return _hashIdRegistrar->getHashForId(trackId);
     }
 
     void ServerInterface::shutDownServer()

--- a/src/server/serverinterface.cpp
+++ b/src/server/serverinterface.cpp
@@ -236,12 +236,13 @@ namespace PMP::Server
         if (hash.isNull())
             return Error::hashIsNull();
 
-        auto maybeHashId = _hashIdRegistrar->getIdForHash(hash);
-        if (maybeHashId == null)
+        auto maybeTrackId = _hashIdRegistrar->getIdForHash(hash);
+        if (maybeTrackId == null)
             return Error::hashIsUnknown();
 
-        auto hashIds =
-            _hashRelations->getEquivalencyGroup(maybeHashId.value());
+        auto trackId = maybeTrackId.value();
+
+        auto trackIds = _hashRelations->getEquivalencyGroup(trackId);
 
         if (userId != 0 && !_users->checkUserIdExists(userId))
             return Error::userIdNotFound();
@@ -251,7 +252,7 @@ namespace PMP::Server
         auto future =
             Concurrent::runOnThreadPool<HistoryFragment, Error>(
                 globalThreadPool,
-                [hashIds, hash, userId, startId, limit]()
+                [trackIds, trackId, hash, userId, startId, limit]()
                     -> ResultOrError<HistoryFragment, Error>
                 {
                     auto db = Database::getDatabaseForCurrentThread();
@@ -259,7 +260,7 @@ namespace PMP::Server
                         return Error::databaseUnvailable();
 
                     const auto recordsOrFailure =
-                        db->getTrackHistoryForUser(userId, hashIds, startId, limit);
+                        db->getTrackHistoryForUser(userId, trackIds, startId, limit);
 
                     if (recordsOrFailure.failed())
                         return Error::internalError();
@@ -272,7 +273,8 @@ namespace PMP::Server
                     for (auto& record : records)
                     {
                         entries.append(
-                            HistoryEntry { hash, userId, record.start, record.end,
+                            HistoryEntry { trackId, hash, userId,
+                                           record.start, record.end,
                                            record.permillage, record.validForScoring }
                         );
                     }

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -32,6 +32,7 @@
 #include "collectiontrackinfo.h"
 #include "hashstats.h"
 #include "historyentry.h"
+#include "queueentryidsandhash.h"
 #include "result.h"
 #include "serverplayerstate.h"
 
@@ -125,6 +126,8 @@ namespace PMP::Server
 
         PlayerStateOverview getPlayerStateOverview();
 
+        QList<ResultOrError<QueueEntryIdsAndHash, Error>> getTrackIdAndHashForQueueIds(
+                                                                        QList<uint> ids);
         Future<QVector<QString>, Error> getPossibleFilenamesForQueueEntry(uint id);
 
         Result insertTrackAtEnd(FileHash hash);
@@ -149,6 +152,7 @@ namespace PMP::Server
 
         void requestHashUserData(quint32 userId, QVector<FileHash> hashes);
         Future<CollectionTrackInfo, Error> getHashInfo(FileHash hash);
+        Nullable<FileHash> getHashForTrackId(uint trackId) const;
 
         void shutDownServer();
         void shutDownServer(QString serverPassword);

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -33,6 +33,7 @@
 #include "hashstats.h"
 #include "historyentry.h"
 #include "queueentryidsandhash.h"
+#include "queueinsertionposition.h"
 #include "result.h"
 #include "serverplayerstate.h"
 
@@ -130,9 +131,10 @@ namespace PMP::Server
                                                                         QList<uint> ids);
         Future<QVector<QString>, Error> getPossibleFilenamesForQueueEntry(uint id);
 
-        Result insertTrackAtEnd(FileHash hash);
-        Result insertTrackAtFront(FileHash hash);
         Result insertBreakAtFrontIfNotExists();
+        Result insertTrack(QueueInsertionPosition position, quint64 trackId);
+        Result insertTrack(QueueInsertionPosition position, FileHash hash);
+        Result insertTrack(quint64 trackId, int index, quint32 clientReference);
         Result insertTrack(FileHash hash, int index, quint32 clientReference);
         Result insertSpecialQueueItem(SpecialQueueItemType itemType,
                                       QueueIndexType indexType, int index,
@@ -199,9 +201,6 @@ namespace PMP::Server
         int toNormalIndex(PlayerQueue const& queue, QueueIndexType indexType, int index);
         std::function<void (uint)> createQueueInsertionIdNotifier(
                                                                  quint32 clientReference);
-        Result insertAtIndex(qint32 index,
-                       std::function<QSharedPointer<QueueEntry> (uint)> queueEntryCreator,
-                       quint32 clientReference);
         void addUserHashDataNotification(quint32 userId, QVector<uint> hashIds);
         void sendUserHashDataNotifications(quint32 userId);
 

--- a/src/server/serverinterface.h
+++ b/src/server/serverinterface.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,8 +17,8 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_SERVERINTERFACE_H
-#define PMP_SERVERINTERFACE_H
+#ifndef PMP_SERVER_SERVERINTERFACE_H
+#define PMP_SERVER_SERVERINTERFACE_H
 
 #include "common/filehash.h"
 #include "common/future.h"
@@ -100,10 +100,10 @@ namespace PMP::Server
         void switchToPersonalMode();
         void switchToPublicMode();
 
-        Future<HistoryFragment, Result> getPersonalTrackHistory(FileHash hash,
-                                                                quint32 userId,
-                                                                uint startId,
-                                                                int limit);
+        Future<HistoryFragment, Error> getPersonalTrackHistory(FileHash hash,
+                                                               quint32 userId,
+                                                               uint startId,
+                                                               int limit);
 
         void requestScrobblingInfo();
         void setScrobblingProviderEnabled(ScrobblingProvider provider, bool enabled);
@@ -125,7 +125,7 @@ namespace PMP::Server
 
         PlayerStateOverview getPlayerStateOverview();
 
-        Future<QVector<QString>, Result> getPossibleFilenamesForQueueEntry(uint id);
+        Future<QVector<QString>, Error> getPossibleFilenamesForQueueEntry(uint id);
 
         Result insertTrackAtEnd(FileHash hash);
         Result insertTrackAtFront(FileHash hash);
@@ -148,7 +148,7 @@ namespace PMP::Server
         void setTrackRepetitionAvoidanceSeconds(int seconds);
 
         void requestHashUserData(quint32 userId, QVector<FileHash> hashes);
-        Future<CollectionTrackInfo, Result> getHashInfo(FileHash hash);
+        Future<CollectionTrackInfo, Error> getHashInfo(FileHash hash);
 
         void shutDownServer();
         void shutDownServer(QString serverPassword);

--- a/src/server/servermetatypes.cpp
+++ b/src/server/servermetatypes.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2018-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2018-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -19,6 +19,7 @@
 
 #include "collectiontrackinfo.h"
 #include "fileanalysis.h"
+#include "filehashwithid.h"
 #include "scrobblingbackend.h"
 #include "scrobblingtrack.h"
 
@@ -39,6 +40,7 @@ namespace PMP::Server
             qRegisterMetaType<PMP::Server::CollectionTrackInfo>();
             qRegisterMetaType<PMP::Server::FileAnalysis>();
             qRegisterMetaType<PMP::Server::FileHashes>();
+            qRegisterMetaType<PMP::Server::FileHashWithId>();
             qRegisterMetaType<PMP::Server::FileInfo>();
             qRegisterMetaType<PMP::Server::ScrobbleResult>();
             qRegisterMetaType<PMP::Server::ScrobblingBackendState>();

--- a/src/server/trackgeneratorbase.cpp
+++ b/src/server/trackgeneratorbase.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -239,7 +239,6 @@ namespace PMP::Server
                                                     qint64 extraMarginMilliseconds)
     {
         return !_repetitionChecker->isRepetitionWhenQueued(candidate.id(),
-                                                           candidate.hash(),
                                                            extraMarginMilliseconds);
     }
 

--- a/src/server/trackinfoproviderimpl.cpp
+++ b/src/server/trackinfoproviderimpl.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2023-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -30,40 +30,41 @@ namespace PMP::Server
     }
 
     Future<CollectionTrackInfo, FailureType> TrackInfoProviderImpl::getTrackInfoAsync(
-                                                                              uint hashId)
+                                                                            uint trackId)
     {
         {
-            auto trackInfo = _resolver->getHashTrackInfo(hashId);
+            auto trackInfo = _resolver->getHashTrackInfo(trackId);
 
             if (!trackInfo.titleAndArtistUnknown())
                 return FutureResult(trackInfo);
         }
 
-        qDebug() << "TrackInfoProviderImpl: will try to locate the file for hash ID"
-                 << hashId;
+        qDebug() << "TrackInfoProviderImpl: will try to locate the file for track ID"
+                 << trackId;
 
         auto future =
-            _resolver->findPathForHashAsync(hashId)
+            _resolver->findPathForTrackAsync(trackId)
                 .thenOnAnyThreadIndirect<SuccessType, FailureType>(
-                    [this, hashId](FailureOr<QString> outcome) -> Future<SuccessType, FailureType>
+                    [this, trackId](FailureOr<QString> outcome)
+                              -> Future<SuccessType, FailureType>
                     {
                         if (outcome.failed())
                             return FutureError<FailureType>(failure);
 
-                        qDebug() << "TrackInfoProviderImpl: have file for hash ID"
-                                 << hashId
+                        qDebug() << "TrackInfoProviderImpl: have file for track ID"
+                                 << trackId
                                  << "and will now wait until Resolver has processed it";
 
-                        return _resolver->waitUntilAnyFileAnalyzed(hashId);
+                        return _resolver->waitUntilAnyFileAnalyzed(trackId);
                     }
                 )
                 .thenOnAnyThread<CollectionTrackInfo, FailureType>(
-                    [this, hashId](SuccessOrFailure) -> FailureOr<CollectionTrackInfo>
+                    [this, trackId](SuccessOrFailure) -> FailureOr<CollectionTrackInfo>
                     {
                         qDebug() << "TrackInfoProviderImpl: will now attempt to return"
-                                    " track info for hash ID" << hashId;
+                                    " track info for hash ID" << trackId;
 
-                        return _resolver->getHashTrackInfo(hashId);
+                        return _resolver->getHashTrackInfo(trackId);
                     }
                 );
 

--- a/src/server/trackinfoproviderimpl.h
+++ b/src/server/trackinfoproviderimpl.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2023-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -31,7 +31,7 @@ namespace PMP::Server
     public:
         TrackInfoProviderImpl(Resolver* resolver);
 
-        Future<CollectionTrackInfo, FailureType> getTrackInfoAsync(uint hashId) override;
+        Future<CollectionTrackInfo, FailureType> getTrackInfoAsync(uint trackId) override;
 
     private:
         Resolver* _resolver;

--- a/src/server/trackrepetitionchecker.cpp
+++ b/src/server/trackrepetitionchecker.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -42,7 +42,7 @@ namespace PMP::Server
         return _noRepetitionSpanSeconds;
     }
 
-    bool TrackRepetitionChecker::isRepetitionWhenQueued(uint id, const FileHash& hash,
+    bool TrackRepetitionChecker::isRepetitionWhenQueued(uint trackId,
                                                         qint64 extraMarginMilliseconds)
     {
         if (_noRepetitionSpanSeconds < 0)
@@ -51,7 +51,7 @@ namespace PMP::Server
         // check occurrence in queue
 
         auto repetition =
-                _queue->checkPotentialRepetitionByAdd(hash, _noRepetitionSpanSeconds,
+                _queue->checkPotentialRepetitionByAdd(trackId, _noRepetitionSpanSeconds,
                                                       extraMarginMilliseconds);
 
         if (repetition.isRepetition())
@@ -65,8 +65,8 @@ namespace PMP::Server
         auto trackNowPlaying = _currentTrack;
         if (trackNowPlaying)
         {
-            auto currentHash = trackNowPlaying->hash().value();
-            if (hash == currentHash)
+            auto currentTrackId = trackNowPlaying->trackId().value();
+            if (trackId == currentTrackId)
                 return true;
         }
 
@@ -76,11 +76,11 @@ namespace PMP::Server
                 QDateTime::currentDateTimeUtc().addMSecs(millisecondsCounted)
                                                .addSecs(-_noRepetitionSpanSeconds);
 
-        QDateTime lastPlay = _history->lastPlayedGloballySinceStartup(hash);
+        QDateTime lastPlay = _history->lastPlayedGloballySinceStartup(trackId);
         if (lastPlay.isValid() && lastPlay > maxLastPlay)
             return true;
 
-        auto maybeUserStats = _history->getUserStats(id, _userPlayingFor);
+        auto maybeUserStats = _history->getUserStats(trackId, _userPlayingFor);
         if (maybeUserStats.isNull())
             return true;
 

--- a/src/server/trackrepetitionchecker.h
+++ b/src/server/trackrepetitionchecker.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020-2022, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2020-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -17,12 +17,11 @@
     with PMP.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef PMP_TRACKREPETITIONCHECKER_H
-#define PMP_TRACKREPETITIONCHECKER_H
-
-#include "common/filehash.h"
+#ifndef PMP_SERVER_TRACKREPETITIONCHECKER_H
+#define PMP_SERVER_TRACKREPETITIONCHECKER_H
 
 #include <QObject>
+#include <QSharedPointer>
 
 namespace PMP::Server
 {
@@ -38,8 +37,7 @@ namespace PMP::Server
 
         int noRepetitionSpanSeconds() const;
 
-        bool isRepetitionWhenQueued(uint id, FileHash const& hash,
-                                    qint64 extraMarginMilliseconds = 0);
+        bool isRepetitionWhenQueued(uint trackId, qint64 extraMarginMilliseconds = 0);
 
     public Q_SLOTS:
         void setUserGeneratingFor(quint32 user);

--- a/tests/test_scrobbler.cpp
+++ b/tests/test_scrobbler.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2018-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2018-2025, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -203,7 +203,8 @@ TrackInfoProviderMock::TrackInfoProviderMock()
 {
     /* create and register the default track to test with */
 
-    CollectionTrackInfo track(FileHash(), true, "Title", "Artist", "Album", "AlbumArtist",
+    CollectionTrackInfo track(1, FileHash(), true,
+                              "Title", "Artist", "Album", "AlbumArtist",
                               /* length (s):*/ 3 * 60 * 1000);
 
     _tracks.insert(1, track);
@@ -229,7 +230,7 @@ void TrackInfoProviderMock::registerTrack(uint hashId, QString title, QString ar
     Q_ASSERT(hashId > 0);
     Q_ASSERT(!_tracks.contains(hashId));
 
-    CollectionTrackInfo track(FileHash(), true, title, artist, album, albumArtist,
+    CollectionTrackInfo track(hashId, FileHash(), true, title, artist, album, albumArtist,
                               /* length (s):*/ 4 * 60 * 1000);
 
     _tracks.insert(hashId, track);

--- a/tests/test_scrobbler.cpp
+++ b/tests/test_scrobbler.cpp
@@ -49,7 +49,7 @@ SimpleFuture<Result> BackendMock::authenticateWithCredentials(QString usernameOr
     Q_UNUSED(usernameOrEmail);
     Q_UNUSED(password);
 
-    return FutureResult(Error::notImplemented());
+    return Error::notImplemented();
 }
 
 void BackendMock::initialize()


### PR DESCRIPTION
This PR adds initial support for using server-side track IDs in client-server communication. Several messages from the server to the client now provide the server-side track ID in addition to the track hash. And the server now accepts track IDs as an alternative to track hashes when inserting a track into the queue.

This is not yet a complete switch from track hashes to server-side track IDs in all client-server communication.