### PR TITLE
Remove MP3 preprocessing

### DIFF
--- a/src/common/fileanalyzer.cpp
+++ b/src/common/fileanalyzer.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2024, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2026, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -181,31 +181,6 @@ namespace PMP
 
         /* all (other) recognized extensions are supported */
         return extensionEnum != Extension::None;
-    }
-
-    bool FileAnalyzer::preprocessFileForPlayback(QByteArray& fileContents,
-                                                 QString extension)
-    {
-        /* only need to do something for MP3 files */
-        if (getExtension(extension) != Extension::MP3) return true;
-
-        /* strip the ID3v2 tag because DirectShow chokes on ID3v2.4 */
-
-        TagLib::ByteVector scratch(fileContents.data(), uint(fileContents.length()));
-        TagLib::ByteVectorStream stream(scratch);
-        TagLib::MPEG::File tagFile(&stream, TagLib::ID3v2::FrameFactory::instance());
-        if (!tagFile.isValid())
-        {
-            return false;
-        }
-
-        tagFile.strip(TagLib::MPEG::File::ID3v2); /* strip the ID3v2 */
-        scratch = *stream.data(); /* get the stripped file contents */
-
-        QByteArray strippedData(scratch.data(), int(scratch.size()));
-        fileContents = strippedData;
-
-        return true; /* success */
     }
 
     FileAnalyzer::Extension FileAnalyzer::getExtension(QString extension)

--- a/src/common/fileanalyzer.h
+++ b/src/common/fileanalyzer.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014-2021, Kevin Andre <hyperquantum@gmail.com>
+    Copyright (C) 2014-2026, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -54,9 +54,6 @@ namespace PMP
                                     bool enableExperimentalFileFormats = false);
         static bool isExtensionSupported(QString const& extension,
                                          bool enableExperimentalFileFormats = false);
-
-        static bool preprocessFileForPlayback(QByteArray& fileContents,
-                                              QString extension);
 
         void analyze();
 

--- a/src/server/preloader.cpp
+++ b/src/server/preloader.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2016-2025, Kevin André <hyperquantum@gmail.com>
+    Copyright (C) 2016-2026, Kevin André <hyperquantum@gmail.com>
 
     This file is part of PMP (Party Music Player).
 
@@ -397,12 +397,6 @@ namespace PMP::Server
 
         qDebug() << "Preloader: read" << contents.size() << "bytes from"
                  << originalFilename << "for queue ID" << queueId;
-
-        if (!FileAnalyzer::preprocessFileForPlayback(contents, extension))
-        {
-            qWarning() << "Preloader: failed to preprocess file" << originalFilename;
-            return failure;
-        }
 
         QString tempDir;
         if (QDir::temp().mkpath("PMP-preload-cache"))


### PR DESCRIPTION
Remove the MP3 preprocessing phase that removes the ID3v2 tag from the preloaded file before playback. This preprocessing was introduced a long time ago because the Windows audio backend that was used by Qt back then (DirectShow) failed to play MP3 files that contained an ID3v2.4 tag. This workaround should no longer be necessary.